### PR TITLE
Removed non-bpg models and renamed bpg models.

### DIFF
--- a/dev/windows/AuroraCPP/AuroraCPP/main.cpp
+++ b/dev/windows/AuroraCPP/AuroraCPP/main.cpp
@@ -32,15 +32,15 @@ void trainDigitRecognizer();
 
 int main() {
 
-	trainTnnMut();
+	trainTnnBpg();
 	return 0;
 
 }
 
 void trainTnnBpg() {
 
-	ptr<model> nlr = neuronLRBpg(0.3);
-	ptr<seqBpg> s = tnnBpg({ 2, 5, 1 }, { nlr, nlr, nlr });
+	ptr<model> nlr = neuronLR(0.3);
+	ptr<seq> s = tnn({ 2, 5, 1 }, { nlr, nlr, nlr });
 
 	vector<ptr<param>*> paramPtrVec = vector<ptr<param>*>();
 	s->modelWise([&paramPtrVec](model* m) { initParam(m, paramPtrVec); });
@@ -202,8 +202,8 @@ void trainTnnMut() {
 
 void trainSyncBpg() {
 
-	ptr<model> nlr = neuronLRBpg(0.3);
-	seqBpg* templateNN = tnnBpg({ 2, 5, 1 }, nlr);
+	ptr<model> nlr = neuronLR(0.3);
+	seq* templateNN = tnn({ 2, 5, 1 }, nlr);
 
 	vector<ptr<param>*> paramPtrVec = vector<ptr<param>*>();
 	templateNN->modelWise([&paramPtrVec](model* m) { initParam(m, paramPtrVec); });
@@ -221,7 +221,7 @@ void trainSyncBpg() {
 		params.push_back(p);
 	}
 
-	syncBpg r = syncBpg(templateNN);
+	sync r = sync(templateNN);
 	r.prep(4);
 	r.unroll(4);
 
@@ -348,11 +348,11 @@ void trainSyncMut() {
 
 void trainLstmBpg() {
 
-	ptr<model> nlr = neuronLRBpg(0.3);
+	ptr<model> nlr = neuronLR(0.3);
 
-	lstmBpg l1 = lstmBpg(7);
-	ptr<model> inNN = tnnBpg({ 2, 7 }, nlr);
-	ptr<model> outNN = tnnBpg({ 7, 1 }, nlr);
+	lstm l1 = lstm(7);
+	ptr<model> inNN = tnn({ 2, 7 }, nlr);
+	ptr<model> outNN = tnn({ 7, 1 }, nlr);
 
 	vector <ptr<param>*> paramPtrVec = vector <ptr<param>*>();
 	inNN->modelWise([&paramPtrVec](model* m) { initParam(m, paramPtrVec); });
@@ -405,10 +405,10 @@ void trainLstmBpg() {
 
 	l1.prep(4);
 	l1.unroll(4);
-	syncBpg rIn = syncBpg(inNN);
+	sync rIn = sync(inNN);
 	rIn.prep(4);
 	rIn.unroll(4);
-	syncBpg rOut = syncBpg(outNN);
+	sync rOut = sync(outNN);
 	rOut.prep(4);
 	rOut.unroll(4);
 
@@ -461,11 +461,11 @@ void trainLstmBpg() {
 
 void trainLstmMut() {
 
-	ptr<model> nlr = neuronLRBpg(0.3);
+	ptr<model> nlr = neuronLR(0.3);
 
-	lstmBpg l1 = lstmBpg(5);
-	ptr<model> inNN = tnnBpg({ 2, 5 }, nlr);
-	ptr<model> outNN = tnnBpg({ 5, 1 }, nlr);
+	lstm l1 = lstm(5);
+	ptr<model> inNN = tnn({ 2, 5 }, nlr);
+	ptr<model> outNN = tnn({ 5, 1 }, nlr);
 
 	vector <ptr<param>*> paramPtrVec = vector <ptr<param>*>();
 	inNN->modelWise([&paramPtrVec](model* m) { initParam(m, paramPtrVec); });
@@ -515,10 +515,10 @@ void trainLstmMut() {
 
 	l1.prep(4);
 	l1.unroll(4);
-	syncBpg rIn = syncBpg(inNN);
+	sync rIn = sync(inNN);
 	rIn.prep(4);
 	rIn.unroll(4);
-	syncBpg rOut = syncBpg(outNN);
+	sync rOut = sync(outNN);
 	rOut.prep(4);
 	rOut.unroll(4);
 
@@ -578,7 +578,7 @@ void trainLstmMut() {
 
 void trainMuBpg() {
 
-	muBpg m1 = muBpg(2, 7, 1);
+	mu m1 = mu(2, 7, 1);
 
 	vector <ptr<param>*> paramPtrVec = vector <ptr<param>*>();
 	m1.modelWise([&paramPtrVec](model* m) { initParam(m, paramPtrVec); });
@@ -805,8 +805,8 @@ void trainMuMut() {
 
 void trainAttBpg() {
 
-	attBpg a1 = attBpg(2, 1);
-	muBpg m1 = muBpg(2, 10, 1);
+	att a1 = att(2, 1);
+	mu m1 = mu(2, 10, 1);
 
 	vector<ptr<param>*> paramPtrVec = vector <ptr<param>*>();
 	a1.modelWise([&paramPtrVec](model* m) { initParam(m, paramPtrVec); });
@@ -885,7 +885,7 @@ void trainAttBpg() {
 			a1.x = tsInputs;
 			for (int j = 0; j < m1.size(); j++) {
 
-				attTSBpg* a = (attTSBpg*)a1.at(j).get();
+				attTS* a = (attTS*)a1.at(j).get();
 				a1.hTIn->vVector.at(j) = m1.hTOut;
 				a1.incFwd(1);
 				m1.x->vVector[m1.index] = a->y;
@@ -895,7 +895,7 @@ void trainAttBpg() {
 			sub2D(m1.y, desired->vVector.at(i), m1.yGrad);
 			for (int j = m1.size() - 1; j >= 0; j--) {
 
-				attTSBpg* a = (attTSBpg*)a1.at(j).get();
+				attTS* a = (attTS*)a1.at(j).get();
 				m1.incBwd(1);
 				a1.yGrad->vVector.at(j) = m1.xGrad->vVector.at(j);
 				a1.incBwd(1);
@@ -926,12 +926,12 @@ void trainAttBpg() {
 
 void trainAccelerator() {
 
-	ptr<model> nlr = neuronLRBpg(0.3);
+	ptr<model> nlr = neuronLR(0.3);
 
 	// initialize the training subject models
-	lstmBpg subLstm(7);
-	syncBpg subSyncIn(tnnBpg({ 2, 7 }, nlr));
-	syncBpg subSyncOut(tnnBpg({ 7, 1 }, nlr));
+	lstm subLstm(7);
+	sync subSyncIn(tnn({ 2, 7 }, nlr));
+	sync subSyncOut(tnn({ 7, 1 }, nlr));
 
 	// initialize the accelerator models
 	muTS* accMuTS = new muTS(1, 10, 1, tnn({1 + 1, 10 + 1}, nlr));
@@ -1241,9 +1241,9 @@ void trainDigitRecognizer() {
 		norm1D(inputs->vVector.at(i), inputs->vVector.at(i));
 	}
 
-	ptr<model> nlr = neuronLRBpg(0.3);
-	ptr<model> nth = neuronThBpg();
-	seqBpg* t = tnnBpg({ (int)inputs->vVector.at(0)->vVector.size(), 24, 16, 1 }, { nth, nth, nth, nlr });
+	ptr<model> nlr = neuronLR(0.3);
+	ptr<model> nth = neuronTh();
+	seq* t = tnn({ (int)inputs->vVector.at(0)->vVector.size(), 24, 16, 1 }, { nth, nth, nth, nlr });
 
 	vector<ptr<param>*> paramPtrVec = vector<ptr<param>*>();
 	t->modelWise([&paramPtrVec](model* m) { initParam(m, paramPtrVec); });
@@ -1263,7 +1263,7 @@ void trainDigitRecognizer() {
 		params.push_back(p);
 	}
 
-	syncBpg s = syncBpg(t);
+	sync s = sync(t);
 
 	s.prep(inputs->vVector.size());
 	s.unroll(inputs->vVector.size());

--- a/dev/windows/AuroraCPP/AuroraCPP/modeling.cpp
+++ b/dev/windows/AuroraCPP/AuroraCPP/modeling.cpp
@@ -3,7 +3,7 @@
 
 #pragma region functions
 
-// functions outside of classes, so they are usable between those of similar types.
+// functions outside of classes
 
 #pragma region external
 seq* tnn(vector<int> npl, vector<ptr<model>> layerNeuronTemplates) {
@@ -15,15 +15,6 @@ seq* tnn(vector<int> npl, vector<ptr<model>> layerNeuronTemplates) {
 	result->push_back(new layer(npl.back(), layerNeuronTemplates.back()));
 	return result;
 }
-seqBpg* tnnBpg(vector<int> npl, vector<ptr<model>> layerNeuronTemplates) {
-	seqBpg* result = new seqBpg();
-	for (int i = 0; i < npl.size() - 1; i++) {
-		result->push_back(new layerBpg(npl.at(i), layerNeuronTemplates.at(i)));
-		result->push_back(new wJuncBpg(npl.at(i), npl.at(i + 1)));
-	}
-	result->push_back(new layerBpg(npl.back(), layerNeuronTemplates.back()));
-	return result;
-}
 seq* tnn(vector<int> npl, ptr<model> neuronTemplate) {
 	seq* result = new seq();
 	for (int i = 0; i < npl.size() - 1; i++) {
@@ -31,15 +22,6 @@ seq* tnn(vector<int> npl, ptr<model> neuronTemplate) {
 		result->push_back(new wJunc(npl.at(i), npl.at(i + 1)));
 	}
 	result->push_back(new layer(npl.back(), neuronTemplate));
-	return result;
-}
-seqBpg* tnnBpg(vector<int> npl, ptr<model> neuronTemplate) {
-	seqBpg* result = new seqBpg();
-	for (int i = 0; i < npl.size() - 1; i++) {
-		result->push_back(new layerBpg(npl.at(i), neuronTemplate));
-		result->push_back(new wJuncBpg(npl.at(i), npl.at(i + 1)));
-	}
-	result->push_back(new layerBpg(npl.back(), neuronTemplate));
 	return result;
 }
 seq* neuronSm() {
@@ -69,39 +51,12 @@ seq* neuronLR(double m) {
 	return nlr;
 
 }
-seqBpg* neuronSmBpg() {
-
-	// construct tanh neuron
-	seqBpg* nsm = new seqBpg();
-	nsm->push_back(new biasBpg());
-	nsm->push_back(new actBpg(new actFuncSm()));
-	return nsm;
-
-}
-seqBpg* neuronThBpg() {
-
-	// construct tanh neuron
-	seqBpg* nth = new seqBpg();
-	nth->push_back(new biasBpg());
-	nth->push_back(new actBpg(new actFuncTh()));
-	return nth;
-
-}
-seqBpg* neuronLRBpg(double m) {
-
-	// construct tanh neuron
-	seqBpg* nlr = new seqBpg();
-	nlr->push_back(new biasBpg());
-	nlr->push_back(new actBpg(new actFuncLR(m)));
-	return nlr;
-
-}
 void initParam(model* m, vector<ptr<param>*>& paramVecOutput) {
 	if (bias* b = dynamic_cast<bias*>(m)) {
 		b->prm = ptr<param>();
 		paramVecOutput.push_back(&b->prm);
 	}
-	else if (biasBpg* b = dynamic_cast<biasBpg*>(m)) {
+	else if (bias* b = dynamic_cast<bias*>(m)) {
 		b->prm = ptr<param>();
 		paramVecOutput.push_back(&b->prm);
 	}
@@ -109,472 +64,10 @@ void initParam(model* m, vector<ptr<param>*>& paramVecOutput) {
 		w->prm = ptr<param>();
 		paramVecOutput.push_back(&w->prm);
 	}
-	else if (weightBpg* w = dynamic_cast<weightBpg*>(m)) {
+	else if (weight* w = dynamic_cast<weight*>(m)) {
 		w->prm = ptr<param>();
 		paramVecOutput.push_back(&w->prm);
 	}
-}
-#pragma endregion
-#pragma region model
-void modelFwd(ptr<cType> x, ptr<cType> y) {
-	*y = *x;
-}
-void modelBwd(ptr<cType> yGrad, ptr<cType> xGrad) {
-	*xGrad = *yGrad;
-}
-#pragma endregion
-#pragma region bias
-void biasFwd(ptr<cType> x, ptr<cType> y, ptr<param> prm) {
-	y->vDouble = x->vDouble + prm->state;
-}
-void biasBwd(ptr<cType> yGrad, ptr<cType> xGrad, ptr<param> prm) {
-	paramSgd* p = (paramSgd*)prm.get();
-	p->gradient += yGrad->vDouble;
-	xGrad->vDouble = yGrad->vDouble;
-}
-#pragma endregion
-#pragma region act
-void actFwd(ptr<cType> x, ptr<cType> y, ptr<actFunc> af) {
-	y->vDouble = af->eval(x->vDouble);
-}
-void actBwd(ptr<cType> x, ptr<cType> yGrad, ptr<cType> y, ptr<cType> xGrad, ptr<actFunc> af) {
-	xGrad->vDouble = yGrad->vDouble * af->deriv(&x->vDouble, &y->vDouble);
-}
-#pragma endregion
-#pragma region weight
-void weightFwd(ptr<cType> x, ptr<cType> y, ptr<param> prm) {
-	y->vDouble = x->vDouble * prm->state;
-}
-void weightBwd(ptr<cType> yGrad, ptr<cType> xGrad, ptr<cType> x, ptr<param> prm) {
-	paramSgd* p = (paramSgd*)prm.get();
-	p->gradient += yGrad->vDouble * x->vDouble;
-	xGrad->vDouble = yGrad->vDouble * prm->state;
-}
-#pragma endregion
-#pragma region wSet
-void wSetFwd(ptr<cType> x, ptr<cType> y, vector<ptr<model>>* models) {
-
-	vector<ptr<cType>>* yVec = &y->vVector;
-	for (int i = 0; i < models->size(); i++) {
-
-		model* m = models->at(i).get();
-		m->x->vDouble = x->vDouble;
-		m->fwd();
-		yVec->at(i)->vDouble = m->y->vDouble;
-
-	}
-
-}
-void wSetBwd(ptr<cType> yGrad, ptr<cType> xGrad, vector<ptr<model>>* models) {
-
-	// reset xGrad of weightSet to avoid overaccumulation
-	xGrad->vDouble = 0;
-
-	vector<ptr<cType>>* yGradVec = &yGrad->vVector;
-	for (int i = 0; i < models->size(); i++) {
-
-		modelBpg* m = (modelBpg*)models->at(i).get();
-		m->yGrad->vDouble = yGradVec->at(i)->vDouble;
-		m->bwd();
-		xGrad->vDouble += m->xGrad->vDouble;
-
-	}
-
-}
-void wSetModelWise(function<void(model*)> func, vector<ptr<model>>* models) {
-	for (int i = 0; i < models->size(); i++) {
-		models->at(i)->modelWise(func);
-	}
-}
-#pragma endregion
-#pragma region wJunc
-void wJuncFwd(ptr<cType> x, ptr<cType> y, vector<ptr<model>>* models) {
-
-	// reset all values in vector to zero, to ensure that no overaccumulation occurs
-	clear1D(y);
-	vector<ptr<cType>>* xVec = &x->vVector;
-	for (int i = 0; i < models->size(); i++) {
-
-		model* m = models->at(i).get();
-		m->x->vDouble = xVec->at(i)->vDouble;
-		m->fwd();
-
-		// accumulates output
-		add1D(y, m->y, y);
-
-	}
-
-}
-void wJuncBwd(ptr<cType> yGrad, ptr<cType> xGrad, vector<ptr<model>>* models) {
-
-	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
-	for (int i = 0; i < models->size(); i++) {
-
-		modelBpg* m = (modelBpg*)models->at(i).get();
-		m->yGrad->vVector = yGrad->vVector;
-		m->bwd();
-		xGradVec->at(i)->vDouble = m->xGrad->vDouble;
-
-	}
-
-}
-void wJuncModelWise(function<void(model*)> func, vector<ptr<model>>* models) {
-	for (int i = 0; i < models->size(); i++) {
-		models->at(i)->modelWise(func);
-	}
-}
-#pragma endregion
-#pragma region seq
-void seqFwd(ptr<cType> x, ptr<cType> y, vector<ptr<model>>* models) {
-
-	ptr<cType> currentInput = x;
-	for (int i = 0; i < models->size(); i++) {
-
-		model* m = models->at(i).get();
-		m->x = currentInput;
-		m->fwd();
-		currentInput = m->y;
-
-	}
-	*y = *currentInput;
-
-}
-void seqBwd(ptr<cType> yGrad, ptr<cType> xGrad, vector<ptr<model>>* models) {
-
-	ptr<cType> currentGradient = yGrad;
-	for (int i = models->size() - 1; i >= 0; i--) {
-
-		modelBpg* m = (modelBpg*)models->at(i).get();
-		m->yGrad = currentGradient;
-		m->bwd();
-		currentGradient = m->xGrad;
-
-	}
-	*xGrad = *currentGradient;
-
-}
-void seqModelWise(function<void(model*)> func, vector<ptr<model>>* models) {
-
-	for (int i = 0; i < models->size(); i++) {
-
-		models->at(i)->modelWise(func);
-
-	}
-
-}
-#pragma endregion
-#pragma region layer
-void layerFwd(ptr<cType> x, ptr<cType> y, vector<ptr<model>>* models) {
-
-	vector<ptr<cType>>* xVec = &x->vVector;
-	vector<ptr<cType>>* yVec = &y->vVector;
-	for (int i = 0; i < models->size(); i++) {
-
-		model* m = models->at(i).get();
-		m->x = xVec->at(i);
-		m->fwd();
-		yVec->at(i) = m->y;
-
-	}
-
-}
-void layerBwd(ptr<cType> yGrad, ptr<cType> xGrad, vector<ptr<model>>* models) {
-
-	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
-	vector<ptr<cType>>* yGradVec = &yGrad->vVector;
-	for (int i = 0; i < models->size(); i++) {
-
-		modelBpg* m = (modelBpg*)models->at(i).get();
-		m->yGrad = yGradVec->at(i);
-		m->bwd();
-		xGradVec->at(i) = m->xGrad;
-
-	}
-
-}
-void layerModelWise(function<void(model*)> func, vector<ptr<model>>* models) {
-	for (int i = 0; i < models->size(); i++) {
-		models->at(i)->modelWise(func);
-	}
-}
-#pragma endregion
-#pragma region sync
-void syncIncFwd(ptr<cType> x, ptr<cType> y, vector<ptr<model>>* models, int* index, int a) {
-
-	vector<ptr<cType>>* xVec = &x->vVector;
-	vector<ptr<cType>>* yVec = &y->vVector;
-
-	for (int j = 0; j < a; j++) {
-
-		int i = *index;
-		model* m = models->at(i).get();
-		m->x = xVec->at(i);
-		m->fwd();
-		yVec->at(i) = m->y;
-		(*index)++;
-
-	}
-
-
-}
-void syncIncBwd(ptr<cType> yGrad, ptr<cType> xGrad, vector<ptr<model>>* models, int* index, int a) {
-
-	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
-	vector<ptr<cType>>* yGradVec = &yGrad->vVector;
-
-	for (int j = 0; j < a; j++) {
-
-		(*index)--;
-		int i = *index;
-		modelBpg* m = (modelBpg*)models->at(i).get();
-		m->yGrad = yGradVec->at(i);
-		m->bwd();
-		xGradVec->at(i) = m->xGrad;
-
-	}
-
-}
-void syncFwd(ptr<cType> x, ptr<cType> y, vector<ptr<model>>* models, int* index) {
-
-	syncIncFwd(x, y, models, index, models->size());
-
-}
-void syncBwd(ptr<cType> yGrad, ptr<cType> xGrad, vector<ptr<model>>* models, int* index) {
-
-	syncIncBwd(yGrad, xGrad, models, index, *index);
-
-}
-void syncModelWise(function<void(model*)> func, ptr<model> modelTemplate) {
-	modelTemplate->modelWise(func);
-}
-#pragma endregion
-#pragma region lstmTS
-void lstmTSFwd(ptr<cType> x, ptr<cType> cTIn, ptr<cType> hTIn,
-	ptr<cType> comp_LenUnits, ptr<cType> comp_Len2Units,
-	ptr<cType> y, ptr<cType> cTOut, ptr<cType> hTOut,
-	ptr<model> aGate, ptr<model> bGate, ptr<model> cGate, ptr<model> dGate) {
-	
-	// import cTypes used for computation output that are of length: units
-	vector<ptr<cType>>* compVec_LenUnits = &comp_LenUnits->vVector;
-	ptr<cType> cT = compVec_LenUnits->at(0);
-	ptr<cType> bYTimescY = compVec_LenUnits->at(1);
-
-	// import cTypes used for computation output that are of length: 2 * units
-	vector<ptr<cType>>* compVec_Len2Units = &comp_Len2Units->vVector;
-	ptr<cType> xConcatHTIn = compVec_Len2Units->at(0);
-
-	concat(x, hTIn, xConcatHTIn);
-
-	copy1D(xConcatHTIn, aGate->x);
-	copy1D(xConcatHTIn, bGate->x);
-	copy1D(xConcatHTIn, cGate->x);
-	copy1D(xConcatHTIn, dGate->x);
-
-	aGate->fwd();
-	bGate->fwd();
-	cGate->fwd();
-	dGate->fwd();
-
-	mult1D(aGate->y, cTIn, cT);
-	mult1D(bGate->y, cGate->y, bYTimescY);
-	add1D(cT, bYTimescY, cTOut);
-	mult1D(cTOut, dGate->y, hTOut);
-	copy1D(hTOut, y);
-
-}
-void lstmTSBwd(int units,
-	ptr<cType> comp_LenUnits, ptr<cType> comp_Len2Units,
-	ptr<cType> cTOut, ptr<cType> cTIn,
-	ptr<cType> yGrad, ptr<cType> cTOutGrad, ptr<cType> hTOutGrad,
-	ptr<cType> xGrad, ptr<cType> cTInGrad, ptr<cType> hTInGrad,
-	ptr<model> aGate, ptr<model> bGate, ptr<model> cGate, ptr<model> dGate) {
-
-	// import cTypes used for computation output that are of length: units
-	vector<ptr<cType>>* compVec_LenUnits = &comp_LenUnits->vVector;
-	ptr<cType> hTGrad = compVec_LenUnits->at(0);
-	ptr<cType> dYTimeshTGrad = compVec_LenUnits->at(1);
-	ptr<cType> cTGrad = compVec_LenUnits->at(2);
-
-	// import cTypes used for computation output that are of length: 2 * units
-	vector<ptr<cType>>* compVec_Len2Units = &comp_Len2Units->vVector;
-	ptr<cType> xGradSum1 = compVec_Len2Units->at(0);
-	ptr<cType> xGradSum2 = compVec_Len2Units->at(1);
-	ptr<cType> xGradSum3 = compVec_Len2Units->at(2);
-
-	// cast all gates to the modelBpgs that they are
-	modelBpg* aGateBpg = (modelBpg*)aGate.get();
-	modelBpg* bGateBpg = (modelBpg*)bGate.get();
-	modelBpg* cGateBpg = (modelBpg*)cGate.get();
-	modelBpg* dGateBpg = (modelBpg*)dGate.get();
-
-	// calculate major gradient tracks
-	add1D(hTOutGrad, yGrad, hTGrad);
-	mult1D(dGateBpg->y, hTGrad, dYTimeshTGrad);
-	add1D(cTOutGrad, dYTimeshTGrad, cTGrad);
-
-	// calculate each gate's output gradient
-	mult1D(hTGrad, cTOut, dGateBpg->yGrad);
-	mult1D(bGateBpg->y, cTGrad, cGateBpg->yGrad);
-	mult1D(cGateBpg->y, cTGrad, bGateBpg->yGrad);
-	mult1D(cTGrad, cTIn, aGateBpg->yGrad);
-
-	mult1D(aGateBpg->y, cTGrad, cTInGrad);
-
-	// carry each gates' gradient backward
-	aGateBpg->bwd();
-	bGateBpg->bwd();
-	cGateBpg->bwd();
-	dGateBpg->bwd();
-
-	add1D(aGateBpg->xGrad, bGateBpg->xGrad, xGradSum1);
-	add1D(cGateBpg->xGrad, dGateBpg->xGrad, xGradSum2);
-	add1D(xGradSum1, xGradSum2, xGradSum3);
-
-	copy1D(xGradSum3, xGrad, 0, units, 0);
-	copy1D(xGradSum3, hTInGrad, units, units, 0);
-
-}
-void lstmTSModelWise(function<void(model*)> func, ptr<model> aGate, ptr<model> bGate, ptr<model> cGate, ptr<model> dGate) {
-	aGate->modelWise(func);
-	bGate->modelWise(func);
-	cGate->modelWise(func);
-	dGate->modelWise(func);
-}
-#pragma endregion
-#pragma region lstm
-void lstmModelWise(function<void(model*)> func, ptr<model> lstmTSTemplate) {
-
-	lstmTSTemplate->modelWise(func);
-
-}
-#pragma endregion
-#pragma region muTS
-void muTSFwd(int xUnits, int cTUnits, int hTUnits, ptr<cType> comp_LenCTUnits, ptr<cType> x, ptr<cType> y, ptr<cType> cTIn, ptr<cType> cTOut, ptr<cType> hTIn, ptr<cType> hTOut, ptr<model> gate) {
-
-	// import compuation cTypes
-	vector<ptr<cType>>* comp_LenCTUnitsVec = &comp_LenCTUnits->vVector;
-	ptr<cType> cTAddOperand = comp_LenCTUnitsVec->at(0);
-
-	concat({ x, cTIn, hTIn }, gate->x);
-	gate->fwd();
-	copy1D(gate->y, cTAddOperand, 0, cTUnits, 0);
-	add1D(cTIn, cTAddOperand, cTOut);
-	copy1D(gate->y, hTOut, cTUnits, hTUnits, 0);
-	copy1D(hTOut, y);
-
-}
-void muTSBwd(int xUnits, int cTUnits, int hTUnits, ptr<cType> comp_LenCTUnits, ptr<cType> comp_LenHTUnits, ptr<cType> xGrad, ptr<cType> yGrad, ptr<cType> cTInGrad, ptr<cType> cTOutGrad, ptr<cType> hTInGrad, ptr<cType> hTOutGrad, ptr<model> gate) {
-
-	// import compuation cTypes
-	vector<ptr<cType>>* comp_LenCTUnitsVec = &comp_LenCTUnits->vVector;
-	ptr<cType> cTCopyOperand = comp_LenCTUnitsVec->at(0);
-
-	vector<ptr<cType>>* comp_LenHTUnitsVec = &comp_LenHTUnits->vVector;
-	ptr<cType> hTAddOperand = comp_LenHTUnitsVec->at(0);
-
-	modelBpg* gateBpg = (modelBpg*)gate.get();
-
-	add1D(yGrad, hTOutGrad, hTAddOperand);
-	copy1D(cTOutGrad, gateBpg->yGrad, 0, cTUnits, 0);
-	copy1D(hTAddOperand, gateBpg->yGrad, 0, hTUnits, cTUnits);
-	gateBpg->bwd();
-	copy1D(gateBpg->xGrad, cTCopyOperand, xUnits, cTUnits, 0);
-	add1D(cTCopyOperand, cTOutGrad, cTInGrad);
-	copy1D(gateBpg->xGrad, xGrad, 0, xUnits, 0);
-	copy1D(gateBpg->xGrad, hTInGrad, xUnits + cTUnits, hTUnits, 0);
-
-}
-void muTSModelWise(function<void(model*)> func, ptr<model> gate) {
-
-	gate->modelWise(func);
-
-}
-#pragma endregion
-#pragma region mu
-void muModelWise(function<void(model*)> func, ptr<model> muTSTemplate) {
-
-	muTSTemplate->modelWise(func);
-
-}
-#pragma endregion
-#pragma region attTS
-void attTSIncFwd(ptr<cType> x, ptr<cType> y, ptr<cType> hTIn, ptr<cType> comp_LenXUnits, int xUnits, int hTUnits, vector<ptr<model>>* unrolled, int* index, int a) {
-
-	vector<ptr<cType>>* comp_LenXUnitsVec = &comp_LenXUnits->vVector;
-	ptr<cType> x_yproduct = comp_LenXUnitsVec->at(0);
-
-	// pull in references to input matrices to save compute
-	vector<ptr<cType>>* xVec = &x->vVector;
-
-	clear1D(y);
-
-	for (int j = 0; j < a; j++) {
-
-		int i = *index;
-		model* m = (model*)unrolled->at(i).get();
-		// set input to the model
-		concat(xVec->at(i), hTIn, m->x);
-		m->fwd();
-		mult1D(m->y, xVec->at(i), x_yproduct);
-		add1D(y, x_yproduct, y);
-
-		(*index)++;
-
-	}
-
-}
-void attTSIncBwd(ptr<cType> x, ptr<cType> yGrad, ptr<cType> xGrad, ptr<cType> hTInGrad, ptr<cType> comp_LenXUnits, ptr<cType> comp_LenHTUnits, int xUnits, int hTUnits, vector<ptr<model>>* unrolled, int* index, int a) {
-
-	vector<ptr<cType>>* comp_LenXUnitsVec = &comp_LenXUnits->vVector;
-	ptr<cType> xGrad_copyResult = comp_LenXUnitsVec->at(0);
-	ptr<cType> y_yGradproduct = comp_LenXUnitsVec->at(1);
-
-	vector<ptr<cType>>* comp_LenHTUnitsVec = &comp_LenHTUnits->vVector;
-	ptr<cType> hTInGrad_copyResult = comp_LenHTUnitsVec->at(0);
-
-	// pull in references to input matrices to save compute
-	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
-	vector<ptr<cType>>* xVec = &x->vVector;
-
-	clear1D(hTInGrad);
-
-	for (int j = 0; j < a; j++) {
-
-		(*index)--;
-		int i = *index;
-		modelBpg* m = (modelBpg*)unrolled->at(i).get();
-
-		mult1D(yGrad, xVec->at(i), m->yGrad);
-		m->bwd();
-		copy1D(m->xGrad, xGrad_copyResult, 0, xUnits, 0);
-		copy1D(m->xGrad, hTInGrad_copyResult, xUnits, hTUnits, 0);
-		add1D(hTInGrad, hTInGrad_copyResult, hTInGrad);
-		mult1D(yGrad, m->y, y_yGradproduct);
-		add1D(y_yGradproduct, xGrad_copyResult, xGradVec->at(i));
-
-	}
-}
-void attTSFwd(ptr<cType> x, ptr<cType> y, ptr<cType> hTIn, ptr<cType> comp_LenXUnits, int xUnits, int hTUnits, vector<ptr<model>>* unrolled, int* index) {
-
-	attTSIncFwd(x, y, hTIn, comp_LenXUnits, xUnits, hTUnits, unrolled, index, unrolled->size() - *index);
-
-}
-void attTSBwd(ptr<cType> x, ptr<cType> yGrad, ptr<cType> xGrad, ptr<cType> hTInGrad, ptr<cType> comp_LenXUnits, ptr<cType> comp_LenHTUnits, int xUnits, int hTUnits, vector<ptr<model>>* unrolled, int* index) {
-
-	attTSIncBwd(x, yGrad, xGrad, hTInGrad, comp_LenXUnits, comp_LenHTUnits, xUnits, hTUnits, unrolled, index, *index);
-
-}
-void attTSModelWise(function<void(model*)> func, ptr<model> seqTemplate) {
-
-	seqTemplate->modelWise(func);
-	
-}
-#pragma endregion
-#pragma region att
-void attModelWise(function<void(model*)> func, ptr<model> attTSTemplate) {
-
-	attTSTemplate->modelWise(func);
-
 }
 #pragma endregion
 
@@ -588,60 +81,39 @@ void attModelWise(function<void(model*)> func, ptr<model> attTSTemplate) {
 model::model() {
 	x = new cType(0);
 	y = new cType(0);
+	xGrad = new cType(0);
+	yGrad = new cType(0);
 }
 void model::fwd() {
-	modelFwd(x, y);
+	*y = *x;
+}
+void model::bwd() {
+	*xGrad = *yGrad;
 }
 void model::modelWise(function<void(model*)> func) {
 	func(this);
 }
 ptr<model> model::clone() {
-	return new model();
-}
-
-modelBpg::modelBpg() {
-	x = new cType(0);
-	y = new cType(0);
-	xGrad = new cType(0);
-	yGrad = new cType(0);
-}
-void modelBpg::bwd() {
-	modelBwd(yGrad, xGrad);
-}
-ptr<model> modelBpg::clone() {
-	return new modelBpg(*this);
+	return new model(*this);
 }
 #pragma endregion
 #pragma region bias
 bias::bias() {
 	x = new cType(0);
 	y = new cType(0);
-}
-void bias::fwd() {
-	biasFwd(x, y, prm);
-}
-ptr<model> bias::clone() {
-	bias* result = new bias();
-	result->x = new cType(*x);
-	result->y = new cType(*y);
-	result->prm = prm;
-	return result;
-}
-
-biasBpg::biasBpg() {
-	x = new cType(0);
-	y = new cType(0);
 	xGrad = new cType(0);
 	yGrad = new cType(0);
 }
-void biasBpg::fwd() {
-	biasFwd(x, y, prm);
+void bias::fwd() {
+	y->vDouble = x->vDouble + prm->state;
 }
-void biasBpg::bwd() {
-	biasBwd(yGrad, xGrad, prm);
+void bias::bwd() {
+	paramSgd* p = (paramSgd*)prm.get();
+	p->gradient += yGrad->vDouble;
+	xGrad->vDouble = yGrad->vDouble;
 }
-ptr<model> biasBpg::clone() {
-	biasBpg* result = new biasBpg();
+ptr<model> bias::clone() {
+	bias* result = new bias();
 	result->x = new cType(*x);
 	result->y = new cType(*y);
 	result->xGrad = new cType(*xGrad);
@@ -657,6 +129,8 @@ act::act() {
 act::act(actFunc* _af) {
 	x = new cType(0);
 	y = new cType(0);
+	xGrad = new cType(0);
+	yGrad = new cType(0);
 	this->af = _af;
 }
 act::act(ptr<actFunc> _af) {
@@ -665,38 +139,13 @@ act::act(ptr<actFunc> _af) {
 	this->af = _af;
 }
 void act::fwd() {
-	actFwd(x, y, af);
+	y->vDouble = af->eval(x->vDouble);
+}
+void act::bwd() {
+	xGrad->vDouble = yGrad->vDouble * af->deriv(&x->vDouble, &y->vDouble);
 }
 ptr<model> act::clone() {
 	act* result = new act();
-	result->x = new cType(*x);
-	result->y = new cType(*y);
-	result->af = af;
-	return result;
-}
-actBpg::actBpg() {
-
-}
-actBpg::actBpg(actFunc* _af) {
-	x = new cType(0);
-	y = new cType(0);
-	xGrad = new cType(0);
-	yGrad = new cType(0);
-	this->af = _af;
-}
-actBpg::actBpg(ptr<actFunc> _af) {
-	x = new cType(0);
-	y = new cType(0);
-	this->af = _af;
-}
-void actBpg::fwd() {
-	actFwd(x, y, af);
-}
-void actBpg::bwd() {
-	actBwd(x, yGrad, y, xGrad, af);
-}
-ptr<model> actBpg::clone() {
-	actBpg* result = new actBpg();
 	result->x = new cType(*x);
 	result->y = new cType(*y);
 	result->xGrad = new cType(*xGrad);
@@ -709,31 +158,19 @@ ptr<model> actBpg::clone() {
 weight::weight() {
 	x = new cType(0);
 	y = new cType(0);
-}
-void weight::fwd() {
-	weightFwd(x, y, prm);
-}
-ptr<model> weight::clone() {
-	weight* result = new weight();
-	result->x = new cType(*x);
-	result->y = new cType(*y);
-	result->prm = prm;
-	return result;
-}
-weightBpg::weightBpg() {
-	x = new cType(0);
-	y = new cType(0);
 	xGrad = new cType(0);
 	yGrad = new cType(0);
 }
-void weightBpg::fwd() {
-	weightFwd(x, y, prm);
+void weight::fwd() {
+	y->vDouble = x->vDouble * prm->state;
 }
-void weightBpg::bwd() {
-	weightBwd(yGrad, xGrad, x, prm);
+void weight::bwd() {
+	paramSgd* p = (paramSgd*)prm.get();
+	p->gradient += yGrad->vDouble * x->vDouble;
+	xGrad->vDouble = yGrad->vDouble * prm->state;
 }
-ptr<model> weightBpg::clone() {
-	weightBpg* result = new weightBpg();
+ptr<model> weight::clone() {
+	weight* result = new weight();
 	result->x = new cType(*x);
 	result->y = new cType(*y);
 	result->xGrad = new cType(*xGrad);
@@ -750,54 +187,51 @@ wSet::wSet(int _a) {
 	this->a = _a;
 	x = new cType(0);
 	y = new cType({});
-	for (int i = 0; i < _a; i++) {
-		y->vVector.push_back(new cType(0));
-		push_back(new weight());
-	}
-}
-void wSet::fwd() {
-	wSetFwd(x, y, this);
-}
-void wSet::modelWise(function<void(model*)> func) {
-	func(this);
-	wSetModelWise(func, this);
-}
-ptr<model> wSet::clone() {
-	wSet* result = new wSet();
-	result->x = new cType(*x);
-	result->y = new cType(*y);
-	for (int i = 0; i < a; i++) {
-		result->push_back(at(i)->clone());
-	}
-	return result;
-}
-wSetBpg::wSetBpg() {
-
-}
-wSetBpg::wSetBpg(int _a) {
-	this->a = _a;
-	x = new cType(0);
-	y = new cType({});
 	xGrad = new cType(0);
 	yGrad = new cType({});
 	for (int i = 0; i < _a; i++) {
 		y->vVector.push_back(new cType(0));
 		yGrad->vVector.push_back(new cType(0));
-		push_back(new weightBpg());
+		push_back(new weight());
 	}
 }
-void wSetBpg::fwd() {
-	wSetFwd(x, y, this);
+void wSet::fwd() {
+
+	vector<ptr<cType>>* yVec = &y->vVector;
+	for (int i = 0; i < size(); i++) {
+
+		model* m = at(i).get();
+		m->x->vDouble = x->vDouble;
+		m->fwd();
+		yVec->at(i)->vDouble = m->y->vDouble;
+
+	}
+
 }
-void wSetBpg::bwd() {
-	wSetBwd(yGrad, xGrad, this);
+void wSet::bwd() {
+
+	// reset xGrad of weightSet to avoid overaccumulation
+	xGrad->vDouble = 0;
+
+	vector<ptr<cType>>* yGradVec = &yGrad->vVector;
+	for (int i = 0; i < size(); i++) {
+
+		model* m = at(i).get();
+		m->yGrad->vDouble = yGradVec->at(i)->vDouble;
+		m->bwd();
+		xGrad->vDouble += m->xGrad->vDouble;
+
+	}
+
 }
-void wSetBpg::modelWise(function<void(model*)> func) {
+void wSet::modelWise(function<void(model*)> func) {
 	func(this);
-	wSetModelWise(func, this);
+	for (int i = 0; i < size(); i++) {
+		at(i)->modelWise(func);
+	}
 }
-ptr<model> wSetBpg::clone() {
-	wSetBpg* result = new wSetBpg();
+ptr<model> wSet::clone() {
+	wSet* result = new wSet();
 	result->x = new cType(*x);
 	result->y = new cType(*y);
 	result->xGrad = new cType(*xGrad);
@@ -813,42 +247,6 @@ wJunc::wJunc() {
 
 }
 wJunc::wJunc(int _a, int _b) {
-	this->a = _a;
-	this->b = _b;
-
-	x = new cType({});
-	y = new cType({});
-
-	for (int i = 0; i < _a; i++) {
-		x->vVector.push_back(new cType(0));
-		push_back(new wSet(b));
-	}
-
-	for (int i = 0; i < _b; i++) {
-		y->vVector.push_back(new cType(0));
-	}
-
-}
-void wJunc::fwd() {
-	wJuncFwd(x, y, this);
-}
-void wJunc::modelWise(function<void(model*)> func) {
-	func(this);
-	wJuncModelWise(func, this);
-}
-ptr<model> wJunc::clone() {
-	wJunc* result = new wJunc();
-	result->x = new cType(*x);
-	result->y = new cType(*y);
-	for (int i = 0; i < a; i++) {
-		result->push_back(at(i)->clone());
-	}
-	return result;
-}
-wJuncBpg::wJuncBpg() {
-
-}
-wJuncBpg::wJuncBpg(int _a, int _b) {
 
 	this->a = _a;
 	this->b = _b;
@@ -861,7 +259,7 @@ wJuncBpg::wJuncBpg(int _a, int _b) {
 	for (int i = 0; i < _a; i++) {
 		x->vVector.push_back(new cType(0));
 		xGrad->vVector.push_back(new cType(0));
-		push_back(new wSetBpg(b));
+		push_back(new wSet(b));
 	}
 
 	for (int i = 0; i < _b; i++) {
@@ -870,18 +268,44 @@ wJuncBpg::wJuncBpg(int _a, int _b) {
 	}
 
 }
-void wJuncBpg::fwd() {
-	wJuncFwd(x, y, this);
+void wJunc::fwd() {
+
+	// reset all values in vector to zero, to ensure that no overaccumulation occurs
+	clear1D(y);
+	vector<ptr<cType>>* xVec = &x->vVector;
+	for (int i = 0; i < size(); i++) {
+
+		model* m = at(i).get();
+		m->x->vDouble = xVec->at(i)->vDouble;
+		m->fwd();
+
+		// accumulates output
+		add1D(y, m->y, y);
+
+	}
+
 }
-void wJuncBpg::bwd() {
-	wJuncBwd(yGrad, xGrad, this);
+void wJunc::bwd() {
+
+	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
+	for (int i = 0; i < size(); i++) {
+
+		model* m = at(i).get();
+		m->yGrad->vVector = yGrad->vVector;
+		m->bwd();
+		xGradVec->at(i)->vDouble = m->xGrad->vDouble;
+
+	}
+
 }
-void wJuncBpg::modelWise(function<void(model*)> func) {
+void wJunc::modelWise(function<void(model*)> func) {
 	func(this);
-	wJuncModelWise(func, this);
+	for (int i = 0; i < size(); i++) {
+		at(i)->modelWise(func);
+	}
 }
-ptr<model> wJuncBpg::clone() {
-	wJuncBpg* result = new wJuncBpg();
+ptr<model> wJunc::clone() {
+	wJunc* result = new wJunc();
 	result->x = new cType(*x);
 	result->y = new cType(*y);
 	result->xGrad = new cType(*xGrad);
@@ -896,42 +320,45 @@ ptr<model> wJuncBpg::clone() {
 seq::seq() {
 	x = new cType(0);
 	y = new cType(0);
-}
-void seq::fwd() {
-	seqFwd(x, y, this);
-}
-void seq::modelWise(function<void(model*)> func) {
-	func(this);
-	seqModelWise(func, this);
-}
-ptr<model> seq::clone() {
-	seq* result = new seq();
-	result->x = new cType(*x);
-	result->y = new cType(*y);
-	for (int i = 0; i < size(); i++) {
-		result->push_back(at(i)->clone());
-	}
-	return result;
-}
-
-seqBpg::seqBpg() {
-	x = new cType(0);
-	y = new cType(0);
 	xGrad = new cType(0);
 	yGrad = new cType(0);
 }
-void seqBpg::fwd() {
-	seqFwd(x, y, this);
+void seq::fwd() {
+
+	ptr<cType> currentInput = x;
+	for (int i = 0; i < size(); i++) {
+
+		model* m = at(i).get();
+		m->x = currentInput;
+		m->fwd();
+		currentInput = m->y;
+
+	}
+	*y = *currentInput;
+
 }
-void seqBpg::bwd() {
-	seqBwd(yGrad, xGrad, this);
+void seq::bwd() {
+
+	ptr<cType> currentGradient = yGrad;
+	for (int i = size() - 1; i >= 0; i--) {
+
+		model* m = at(i).get();
+		m->yGrad = currentGradient;
+		m->bwd();
+		currentGradient = m->xGrad;
+
+	}
+	*xGrad = *currentGradient;
+
 }
-void seqBpg::modelWise(function<void(model*)> func) {
+void seq::modelWise(function<void(model*)> func) {
 	func(this);
-	seqModelWise(func, this);
+	for (int i = 0; i < size(); i++) {
+		at(i)->modelWise(func);
+	}
 }
-ptr<model> seqBpg::clone() {
-	seqBpg* result = new seqBpg();
+ptr<model> seq::clone() {
+	seq* result = new seq();
 	result->x = new cType(*x);
 	result->y = new cType(*y);
 	result->xGrad = new cType(*xGrad);
@@ -945,20 +372,27 @@ ptr<model> seqBpg::clone() {
 #pragma region layer
 layer::layer() {
 
+	// initialized the x, y, xGrad, yGrad cTypes as vectors to insure that all members of the cType are initialized
 	x = new cType({});
 	y = new cType({});
+	xGrad = new cType({});
+	yGrad = new cType({});
 
 }
 layer::layer(int a, model* modelTemplate) {
 
 	x = new cType({});
 	y = new cType({});
+	xGrad = new cType({});
+	yGrad = new cType({});
 
 	for (int i = 0; i < a; i++) {
 
-		// initialize the x, y cTypes as vectors to insure that all members of the cType are initialized
+		// initialize the x, y, xGrad, yGrad cTypes as vectors to insure that all members of the cType are initialized
 		x->vVector.push_back(new cType({}));
 		y->vVector.push_back(new cType({}));
+		xGrad->vVector.push_back(new cType({}));
+		yGrad->vVector.push_back(new cType({}));
 
 		push_back(modelTemplate->clone());
 
@@ -969,95 +403,58 @@ layer::layer(int a, ptr<model> modelTemplate) {
 
 	x = new cType({});
 	y = new cType({});
+	xGrad = new cType({});
+	yGrad = new cType({});
 
 	for (int i = 0; i < a; i++) {
 
-		// initialize the x, y cTypes as vectors to insure that all members of the cType are initialized
+		// initialize the x, y, xGrad, yGrad cTypes as vectors to insure that all members of the cType are initialized
 		x->vVector.push_back(new cType({}));
 		y->vVector.push_back(new cType({}));
-		
+		xGrad->vVector.push_back(new cType({}));
+		yGrad->vVector.push_back(new cType({}));
+
 		push_back(modelTemplate->clone());
 
 	}
 
 }
 void layer::fwd() {
-	layerFwd(x, y, this);
+
+	vector<ptr<cType>>* xVec = &x->vVector;
+	vector<ptr<cType>>* yVec = &y->vVector;
+	for (int i = 0; i < size(); i++) {
+
+		model* m = at(i).get();
+		m->x = xVec->at(i);
+		m->fwd();
+		yVec->at(i) = m->y;
+
+	}
+
+}
+void layer::bwd() {
+
+	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
+	vector<ptr<cType>>* yGradVec = &yGrad->vVector;
+	for (int i = 0; i < size(); i++) {
+
+		model* m = at(i).get();
+		m->yGrad = yGradVec->at(i);
+		m->bwd();
+		xGradVec->at(i) = m->xGrad;
+
+	}
+
 }
 void layer::modelWise(function<void(model*)> func) {
 	func(this);
-	layerModelWise(func, this);
+	for (int i = 0; i < size(); i++) {
+		at(i)->modelWise(func);
+	}
 }
 ptr<model> layer::clone() {
 	layer* result = new layer();
-	result->x = new cType(*x);
-	result->y = new cType(*y);
-	for (int i = 0; i < size(); i++) {
-		result->push_back(at(i)->clone());
-	}
-	return result;
-}
-layerBpg::layerBpg() {
-
-	// initialized the x, y, xGrad, yGrad cTypes as vectors to insure that all members of the cType are initialized
-	x = new cType({});
-	y = new cType({});
-	xGrad = new cType({});
-	yGrad = new cType({});
-
-}
-layerBpg::layerBpg(int a, model* modelTemplate) {
-
-	x = new cType({});
-	y = new cType({});
-	xGrad = new cType({});
-	yGrad = new cType({});
-
-	for (int i = 0; i < a; i++) {
-
-		// initialize the x, y, xGrad, yGrad cTypes as vectors to insure that all members of the cType are initialized
-		x->vVector.push_back(new cType({}));
-		y->vVector.push_back(new cType({}));
-		xGrad->vVector.push_back(new cType({}));
-		yGrad->vVector.push_back(new cType({}));
-
-		push_back(modelTemplate->clone());
-
-	}
-
-}
-layerBpg::layerBpg(int a, ptr<model> modelTemplate) {
-
-	x = new cType({});
-	y = new cType({});
-	xGrad = new cType({});
-	yGrad = new cType({});
-
-	for (int i = 0; i < a; i++) {
-
-		// initialize the x, y, xGrad, yGrad cTypes as vectors to insure that all members of the cType are initialized
-		x->vVector.push_back(new cType({}));
-		y->vVector.push_back(new cType({}));
-		xGrad->vVector.push_back(new cType({}));
-		yGrad->vVector.push_back(new cType({}));
-
-		push_back(modelTemplate->clone());
-
-	}
-
-}
-void layerBpg::fwd() {
-	layerFwd(x, y, this);
-}
-void layerBpg::bwd() {
-	layerBwd(yGrad, xGrad, this);
-}
-void layerBpg::modelWise(function<void(model*)> func) {
-	func(this);
-	layerModelWise(func, this);
-}
-ptr<model> layerBpg::clone() {
-	layerBpg* result = new layerBpg();
 	result->x = new cType(*x);
 	result->y = new cType(*y);
 	result->xGrad = new cType(*xGrad);
@@ -1081,21 +478,53 @@ sync::sync(ptr<model> _modelTemplate) {
 	prepared = vector<ptr<model>>();
 }
 void sync::fwd() {
-	syncFwd(x, y, this, &index);
+	incFwd(size());
 }
 void sync::incFwd(int a) {
 
-	syncIncFwd(x, y, this, &index, a);
+	vector<ptr<cType>>* xVec = &x->vVector;
+	vector<ptr<cType>>* yVec = &y->vVector;
+
+	for (int j = 0; j < a; j++) {
+
+		model* m = at(index).get();
+		m->x = xVec->at(index);
+		m->fwd();
+		yVec->at(index) = m->y;
+		index++;
+
+	}
+
+}
+void sync::bwd() {
+	incBwd(index);
+}
+void sync::incBwd(int a) {
+
+	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
+	vector<ptr<cType>>* yGradVec = &yGrad->vVector;
+
+	for (int j = 0; j < a; j++) {
+
+		index--;
+		model* m = at(index).get();
+		m->yGrad = yGradVec->at(index);
+		m->bwd();
+		xGradVec->at(index) = m->xGrad;
+
+	}
 
 }
 void sync::modelWise(function<void(model*)> func) {
 	func(this);
-	syncModelWise(func, modelTemplate);
+	modelTemplate->modelWise(func);
 }
 ptr<model> sync::clone() {
 	sync* result = new sync();
 	result->x = new cType(*x);
 	result->y = new cType(*y);
+	result->xGrad = new cType(*xGrad);
+	result->yGrad = new cType(*yGrad);
 	result->modelTemplate = modelTemplate;
 	return result;
 }
@@ -1113,72 +542,6 @@ void sync::unroll(int a) {
 
 		x->vVector.push_back(new cType({}));
 		y->vVector.push_back(new cType({}));
-
-		push_back(prepared.at(size()));
-
-	}
-}
-void sync::clear() {
-	vector<ptr<model>>::clear();
-	x->vVector.clear();
-	y->vVector.clear();
-	index = 0;
-}
-
-syncBpg::syncBpg() {
-	prepared = vector<ptr<model>>();
-}
-syncBpg::syncBpg(model* _modelTemplate) {
-	this->modelTemplate = _modelTemplate;
-	prepared = vector<ptr<model>>();
-}
-syncBpg::syncBpg(ptr<model> _modelTemplate) {
-	this->modelTemplate = _modelTemplate;
-	prepared = vector<ptr<model>>();
-}
-void syncBpg::fwd() {
-	syncFwd(x, y, this, &index);
-}
-void syncBpg::incFwd(int a) {
-
-	syncIncFwd(x, y, this, &index, a);
-
-}
-void syncBpg::bwd() {
-	syncBwd(yGrad, xGrad, this, &index);
-}
-void syncBpg::incBwd(int a) {
-
-	syncIncBwd(yGrad, xGrad, this, &index, a);
-
-}
-void syncBpg::modelWise(function<void(model*)> func) {
-	func(this);
-	syncModelWise(func, modelTemplate);
-}
-ptr<model> syncBpg::clone() {
-	syncBpg* result = new syncBpg();
-	result->x = new cType(*x);
-	result->y = new cType(*y);
-	result->xGrad = new cType(*xGrad);
-	result->yGrad = new cType(*yGrad);
-	result->modelTemplate = modelTemplate;
-	return result;
-}
-void syncBpg::prep(int a) {
-	for (int i = 0; i < a; i++) {
-		prepared.push_back(modelTemplate->clone());
-	}
-}
-void syncBpg::unroll(int a) {
-
-	// insure that the requested unroll size, 'a' will not cause there to be more instantiations of modelTemplate used than there are prepared
-	assert(size() + a <= prepared.size());
-
-	for (int i = 0; i < a; i++) {
-
-		x->vVector.push_back(new cType({}));
-		y->vVector.push_back(new cType({}));
 		xGrad->vVector.push_back(new cType({}));
 		yGrad->vVector.push_back(new cType({}));
 
@@ -1186,7 +549,7 @@ void syncBpg::unroll(int a) {
 
 	}
 }
-void syncBpg::clear() {
+void sync::clear() {
 	vector<ptr<model>>::clear();
 	x->vVector.clear();
 	y->vVector.clear();
@@ -1217,68 +580,14 @@ lstmTS::lstmTS(int _units, ptr<model> _aGate, ptr<model> _bGate, ptr<model> _cGa
 
 	this->x = make1D(units);
 	this->y = make1D(units);
-
-	this->aGate->x = make1D(2 * units);
-	this->aGate->y = make1D(units);
-	this->bGate->x = make1D(2 * units);
-	this->bGate->y = make1D(units);
-	this->cGate->x = make1D(2 * units);
-	this->cGate->y = make1D(units);
-	this->dGate->x = make1D(2 * units);
-	this->dGate->y = make1D(units);
-
-	this->cTIn = make1D(units);
-	this->cTOut = make1D(units);
-	this->hTIn = make1D(units);
-	this->hTOut = make1D(units);
-
-	comp_LenUnits = make2D(3, units);
-	comp_Len2Units = make2D(1, 2 * units);
-
-}
-void lstmTS::fwd() {
-	lstmTSFwd(x, cTIn, hTIn, comp_LenUnits, comp_Len2Units, y, cTOut, hTOut, aGate, bGate, cGate, dGate);
-}
-void lstmTS::modelWise(function<void(model*)> func) {
-	func(this);
-	lstmTSModelWise(func, aGate, bGate, cGate, dGate);
-}
-ptr<model> lstmTS::clone() {
-
-	lstmTS* result = new lstmTS(units, aGate->clone(), bGate->clone(), cGate->clone(), dGate->clone());
-	return result;
-
-}
-
-lstmTSBpg::lstmTSBpg() {
-
-	this->x = new cType({});
-	this->y = new cType({});
-
-	this->cTIn = new cType({});
-	this->cTOut = new cType({});
-	this->hTIn = new cType({});
-	this->hTOut = new cType({});
-
-}
-lstmTSBpg::lstmTSBpg(int _units, ptr<model> _aGate, ptr<model> _bGate, ptr<model> _cGate, ptr<model> _dGate) {
-
-	this->units = _units;
-	this->aGate = _aGate;
-	this->bGate = _bGate;
-	this->cGate = _cGate;
-	this->dGate = _dGate;
-
-	this->x = make1D(units);
-	this->y = make1D(units);
 	this->xGrad = make1D(units);
 	this->yGrad = make1D(units);
 
-	// cast all gates to the modelBpgs that they are
-	modelBpg* aGateBpg = (modelBpg*)aGate.get();
-	modelBpg* bGateBpg = (modelBpg*)bGate.get();
-	modelBpg* cGateBpg = (modelBpg*)cGate.get();
-	modelBpg* dGateBpg = (modelBpg*)dGate.get();
+	// cast all gates to the models that they are
+	model* aGateBpg = (model*)aGate.get();
+	model* bGateBpg = (model*)bGate.get();
+	model* cGateBpg = (model*)cGate.get();
+	model* dGateBpg = (model*)dGate.get();
 
 	aGateBpg->x = make1D(2 * units);
 	aGateBpg->y = make1D(units);
@@ -1311,22 +620,93 @@ lstmTSBpg::lstmTSBpg(int _units, ptr<model> _aGate, ptr<model> _bGate, ptr<model
 	this->comp_Len2Units = make2D(3, 2 * units);
 
 }
-void lstmTSBpg::fwd() {
-	lstmTSFwd(x, cTIn, hTIn, comp_LenUnits, comp_Len2Units, y, cTOut, hTOut, aGate, bGate, cGate, dGate);
-}
-void lstmTSBpg::bwd() {
-	lstmTSBwd(units, comp_LenUnits, comp_Len2Units,
-		cTOut, cTIn, yGrad,
-		cTOutGrad, hTOutGrad, xGrad, cTInGrad, hTInGrad, 
-		aGate, bGate, cGate, dGate);
-}
-void lstmTSBpg::modelWise(function<void(model*)> func) {
-	func(this);
-	lstmTSModelWise(func, aGate, bGate, cGate, dGate);
-}
-ptr<model> lstmTSBpg::clone() {
+void lstmTS::fwd() {
 
-	lstmTSBpg* result = new lstmTSBpg(units, aGate->clone(), bGate->clone(), cGate->clone(), dGate->clone());
+	// import cTypes used for computation output that are of length: units
+	vector<ptr<cType>>* compVec_LenUnits = &comp_LenUnits->vVector;
+	ptr<cType> cT = compVec_LenUnits->at(0);
+	ptr<cType> bYTimescY = compVec_LenUnits->at(1);
+
+	// import cTypes used for computation output that are of length: 2 * units
+	vector<ptr<cType>>* compVec_Len2Units = &comp_Len2Units->vVector;
+	ptr<cType> xConcatHTIn = compVec_Len2Units->at(0);
+
+	concat(x, hTIn, xConcatHTIn);
+
+	copy1D(xConcatHTIn, aGate->x);
+	copy1D(xConcatHTIn, bGate->x);
+	copy1D(xConcatHTIn, cGate->x);
+	copy1D(xConcatHTIn, dGate->x);
+
+	aGate->fwd();
+	bGate->fwd();
+	cGate->fwd();
+	dGate->fwd();
+
+	mult1D(aGate->y, cTIn, cT);
+	mult1D(bGate->y, cGate->y, bYTimescY);
+	add1D(cT, bYTimescY, cTOut);
+	mult1D(cTOut, dGate->y, hTOut);
+	copy1D(hTOut, y);
+
+}
+void lstmTS::bwd() {
+
+	// import cTypes used for computation output that are of length: units
+	vector<ptr<cType>>* compVec_LenUnits = &comp_LenUnits->vVector;
+	ptr<cType> hTGrad = compVec_LenUnits->at(0);
+	ptr<cType> dYTimeshTGrad = compVec_LenUnits->at(1);
+	ptr<cType> cTGrad = compVec_LenUnits->at(2);
+
+	// import cTypes used for computation output that are of length: 2 * units
+	vector<ptr<cType>>* compVec_Len2Units = &comp_Len2Units->vVector;
+	ptr<cType> xGradSum1 = compVec_Len2Units->at(0);
+	ptr<cType> xGradSum2 = compVec_Len2Units->at(1);
+	ptr<cType> xGradSum3 = compVec_Len2Units->at(2);
+
+	// cast all gates to the models that they are
+	model* aGateBpg = (model*)aGate.get();
+	model* bGateBpg = (model*)bGate.get();
+	model* cGateBpg = (model*)cGate.get();
+	model* dGateBpg = (model*)dGate.get();
+
+	// calculate major gradient tracks
+	add1D(hTOutGrad, yGrad, hTGrad);
+	mult1D(dGateBpg->y, hTGrad, dYTimeshTGrad);
+	add1D(cTOutGrad, dYTimeshTGrad, cTGrad);
+
+	// calculate each gate's output gradient
+	mult1D(hTGrad, cTOut, dGateBpg->yGrad);
+	mult1D(bGateBpg->y, cTGrad, cGateBpg->yGrad);
+	mult1D(cGateBpg->y, cTGrad, bGateBpg->yGrad);
+	mult1D(cTGrad, cTIn, aGateBpg->yGrad);
+
+	mult1D(aGateBpg->y, cTGrad, cTInGrad);
+
+	// carry each gates' gradient backward
+	aGateBpg->bwd();
+	bGateBpg->bwd();
+	cGateBpg->bwd();
+	dGateBpg->bwd();
+
+	add1D(aGateBpg->xGrad, bGateBpg->xGrad, xGradSum1);
+	add1D(cGateBpg->xGrad, dGateBpg->xGrad, xGradSum2);
+	add1D(xGradSum1, xGradSum2, xGradSum3);
+
+	copy1D(xGradSum3, xGrad, 0, units, 0);
+	copy1D(xGradSum3, hTInGrad, units, units, 0);
+
+}
+void lstmTS::modelWise(function<void(model*)> func) {
+	func(this);
+	aGate->modelWise(func);
+	bGate->modelWise(func);
+	cGate->modelWise(func);
+	dGate->modelWise(func);
+}
+ptr<model> lstmTS::clone() {
+
+	lstmTS* result = new lstmTS(units, aGate->clone(), bGate->clone(), cGate->clone(), dGate->clone());
 	return result;
 
 }
@@ -1353,43 +733,27 @@ lstm::lstm(int _units) {
 	this->hTOut = make1D(units);
 	this->cTOut = make1D(units);
 
+	this->hTInGrad = make1D(units);
+	this->cTInGrad = make1D(units);
+	this->hTOutGrad = make1D(units);
+	this->cTOutGrad = make1D(units);
+
 	this->lstmTSTemplate = new lstmTS(units, aGate, bGate, cGate, dGate);
 
 }
-//lstm::lstm(int _units, vector<int> _gateHiddenLayers) {
-//
-//	this->units = _units;
-//
-//	ptr<model> nlr = neuronLR(0.3);
-//	ptr<model> nth = neuronTh();
-//	ptr<model> nsm = neuronSm();
-//
-//	vector<int> gateDims = concat(concat({ 2 * units }, _gateHiddenLayers), { units });
-//
-//	ptr<model> aGate = tnn(gateDims, { nlr, nsm });
-//	ptr<model> bGate = tnn(gateDims, { nlr, nsm });
-//	ptr<model> cGate = tnn(gateDims, { nlr, nth });
-//	ptr<model> dGate = tnn(gateDims, { nlr, nsm });
-//
-//	this->hTIn = make1D(units);
-//	this->cTIn = make1D(units);
-//	this->hTOut = make1D(units);
-//	this->cTOut = make1D(units);
-//
-//	this->lstmTSTemplate = new lstmTS(units, aGate, bGate, cGate, dGate);
-//
-//}
-//lstm::lstm(int _units, vector<int> _aGateHiddenLayers, vector<int> _bGateHiddenLayers, vector<int> _cGateHiddenLayers, vector<int> _dGateHiddenLayers) {
-//
-//}
 lstm::lstm(int _units, ptr<model> _aGate, ptr<model> _bGate, ptr<model> _cGate, ptr<model> _dGate) {
-	
+
 	this->units = _units;
 
 	this->hTIn = make1D(units);
 	this->cTIn = make1D(units);
 	this->hTOut = make1D(units);
 	this->cTOut = make1D(units);
+
+	this->hTInGrad = make1D(units);
+	this->cTInGrad = make1D(units);
+	this->hTOutGrad = make1D(units);
+	this->cTOutGrad = make1D(units);
 
 	this->lstmTSTemplate = new lstmTS(units, _aGate, _bGate, _cGate, _dGate);
 
@@ -1437,138 +801,12 @@ void lstm::incFwd(int a) {
 	hTOut->vVector = hT->vVector;*/
 
 }
-void lstm::modelWise(function<void(model*)> func) {
-
-	func(this);
-	lstmModelWise(func, lstmTSTemplate);
-
-}
-ptr<model> lstm::clone() {
-
-	lstm* result = new lstm();
-	result->units = units;
-	result->lstmTSTemplate = lstmTSTemplate->clone();
-	return result;
-
-}
-void lstm::prep(int a) {
-	for (int i = 0; i < a; i++) {
-		prepared.push_back(lstmTSTemplate->clone());
-	}
-}
-void lstm::unroll(int a) {
-	for (int i = 0; i < a; i++) {
-		push_back(prepared.at(size()));
-		x->vVector.push_back(new cType{});
-		y->vVector.push_back(new cType{});
-	}
-}
-void lstm::clear() {
-	vector<ptr<model>>::clear();
-	x->vVector.clear();
-	y->vVector.clear();
-	clear1D(cTIn);
-	clear1D(hTIn);
-	clear1D(cTOut);
-	clear1D(hTOut);
-	index = 0;
-}
-
-lstmBpg::lstmBpg() {
-
-}
-lstmBpg::lstmBpg(int _units) {
-
-	this->units = _units;
-
-	ptr<model> nlr = neuronLRBpg(0.3);
-	ptr<model> nth = neuronThBpg();
-	ptr<model> nsm = neuronSmBpg();
-
-	ptr<model> aGate = tnnBpg({ 2 * units, units }, { nlr, nsm });
-	ptr<model> bGate = tnnBpg({ 2 * units, units }, { nlr, nsm });
-	ptr<model> cGate = tnnBpg({ 2 * units, units }, { nlr, nth });
-	ptr<model> dGate = tnnBpg({ 2 * units, units }, { nlr, nsm });
-
-	this->hTIn = make1D(units);
-	this->cTIn = make1D(units);
-	this->hTOut = make1D(units);
-	this->cTOut = make1D(units);
-
-	this->hTInGrad = make1D(units);
-	this->cTInGrad = make1D(units);
-	this->hTOutGrad = make1D(units);
-	this->cTOutGrad = make1D(units);
-
-	this->lstmTSTemplate = new lstmTSBpg(units, aGate, bGate, cGate, dGate);
-
-}
-lstmBpg::lstmBpg(int _units, ptr<model> _aGate, ptr<model> _bGate, ptr<model> _cGate, ptr<model> _dGate) {
-
-	this->units = _units;
-
-	this->hTIn = make1D(units);
-	this->cTIn = make1D(units);
-	this->hTOut = make1D(units);
-	this->cTOut = make1D(units);
-
-	this->hTInGrad = make1D(units);
-	this->cTInGrad = make1D(units);
-	this->hTOutGrad = make1D(units);
-	this->cTOutGrad = make1D(units);
-
-	this->lstmTSTemplate = new lstmTSBpg(units, _aGate, _bGate, _cGate, _dGate);
-
-}
-void lstmBpg::fwd() {
-
-	incFwd(size() - index);
-
-}
-void lstmBpg::incFwd(int a) {
-
-	vector<ptr<cType>>* xVec = &x->vVector;
-	vector<ptr<cType>>* yVec = &y->vVector;
-
-	ptr<cType> cT = make1D(units);
-	ptr<cType> hT = make1D(units);
-
-	if (index == 0) {
-		copy1D(cTIn, cT);
-		copy1D(hTIn, hT);
-	}
-	else {
-		copy1D(cTOut, cT);
-		copy1D(hTOut, hT);
-	}
-
-	for (int j = 0; j < a; j++) {
-
-		lstmTSBpg* l = (lstmTSBpg*)at(index).get();
-		l->x = xVec->at(index);
-		l->cTIn = cT;
-		l->hTIn = hT;
-		l->fwd();
-		yVec->at(index) = l->y;
-		cT = l->cTOut;
-		hT = l->hTOut;
-
-		index++;
-
-	}
-
-	copy1D(cT, cTOut);
-	copy1D(hT, hTOut);
-	/*cTOut->vVector = cT->vVector;
-	hTOut->vVector = hT->vVector;*/
-
-}
-void lstmBpg::bwd() {
+void lstm::bwd() {
 
 	incBwd(index);
 
 }
-void lstmBpg::incBwd(int a) {
+void lstm::incBwd(int a) {
 
 	vector<ptr<cType>>* yGradVec = &yGrad->vVector;
 	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
@@ -1589,7 +827,7 @@ void lstmBpg::incBwd(int a) {
 
 		index--;
 
-		lstmTSBpg* l = (lstmTSBpg*)at(index).get();
+		lstmTS* l = (lstmTS*)at(index).get();
 		l->yGrad = yGradVec->at(index);
 		l->cTOutGrad = cTGrad;
 		l->hTOutGrad = hTGrad;
@@ -1604,26 +842,26 @@ void lstmBpg::incBwd(int a) {
 	copy1D(hTGrad, hTInGrad);
 
 }
-void lstmBpg::modelWise(function<void(model*)> func) {
+void lstm::modelWise(function<void(model*)> func) {
 	
 	func(this);
-	lstmModelWise(func, lstmTSTemplate);
+	lstmTSTemplate->modelWise(func);
 
 }
-ptr<model> lstmBpg::clone() {
+ptr<model> lstm::clone() {
 
-	lstmBpg* result = new lstmBpg();
+	lstm* result = new lstm();
 	result->units = units;
 	result->lstmTSTemplate = lstmTSTemplate->clone();
 	return result;
 
 }
-void lstmBpg::prep(int a) {
+void lstm::prep(int a) {
 	for (int i = 0; i < a; i++) {
 		prepared.push_back(lstmTSTemplate->clone());
 	}
 }
-void lstmBpg::unroll(int a) {
+void lstm::unroll(int a) {
 	for (int i = 0; i < a; i++) {
 		push_back(prepared.at(size()));
 		x->vVector.push_back(new cType{});
@@ -1632,7 +870,7 @@ void lstmBpg::unroll(int a) {
 		yGrad->vVector.push_back(new cType{});
 	}
 }
-void lstmBpg::clear() {
+void lstm::clear() {
 	vector<ptr<model>>::clear();
 	x->vVector.clear();
 	y->vVector.clear();
@@ -1654,48 +892,6 @@ muTS::muTS() {
 
 }
 muTS::muTS(int _xUnits, int _cTUnits, int _hTUnits, ptr<model> _gate) {
-	
-	this->xUnits = _xUnits;
-	this->cTUnits = _cTUnits;
-	this->hTUnits = _hTUnits;
-	this->gate = _gate;
-
-	this->x = make1D(xUnits);
-	this->y = make1D(hTUnits);
-
-	this->gate->x = make1D(xUnits + cTUnits + hTUnits);
-	this->gate->y = make1D(cTUnits + hTUnits);
-
-	this->cTIn = make1D(cTUnits);
-	this->cTOut = make1D(cTUnits);
-	this->hTIn = make1D(hTUnits);
-	this->hTOut = make1D(hTUnits);
-
-	this->comp_LenCTUnits = make2D(1, cTUnits);
-
-}
-void muTS::fwd() {
-
-	muTSFwd(xUnits, cTUnits, hTUnits, comp_LenCTUnits, x, y, cTIn, cTOut, hTIn, hTOut, gate);
-
-}
-void muTS::modelWise(function<void(model*)> func) {
-
-	func(this);
-	muTSModelWise(func, gate);
-
-}
-ptr<model> muTS::clone() {
-
-	muTS* result = new muTS(xUnits, cTUnits, hTUnits, gate->clone());
-	return result;
-
-}
-
-muTSBpg::muTSBpg() {
-
-}
-muTSBpg::muTSBpg(int _xUnits, int _cTUnits, int _hTUnits, ptr<model> _gate) {
 
 	this->xUnits = _xUnits;
 	this->cTUnits = _cTUnits;
@@ -1707,7 +903,7 @@ muTSBpg::muTSBpg(int _xUnits, int _cTUnits, int _hTUnits, ptr<model> _gate) {
 	this->xGrad = make1D(xUnits);
 	this->yGrad = make1D(hTUnits);
 
-	modelBpg* gateBpg = (modelBpg*)gate.get();
+	model* gateBpg = (model*)gate.get();
 
 	gateBpg->x = make1D(xUnits + cTUnits + hTUnits);
 	gateBpg->y = make1D(cTUnits + hTUnits);
@@ -1728,25 +924,50 @@ muTSBpg::muTSBpg(int _xUnits, int _cTUnits, int _hTUnits, ptr<model> _gate) {
 	this->comp_LenHTUnits = make2D(1, hTUnits);
 
 }
-void muTSBpg::fwd() {
+void muTS::fwd() {
 
-	muTSFwd(xUnits, cTUnits, hTUnits, comp_LenCTUnits, x, y, cTIn, cTOut, hTIn, hTOut, gate);
+	// import compuation cTypes
+	vector<ptr<cType>>* comp_LenCTUnitsVec = &comp_LenCTUnits->vVector;
+	ptr<cType> cTAddOperand = comp_LenCTUnitsVec->at(0);
+
+	concat({ x, cTIn, hTIn }, gate->x);
+	gate->fwd();
+	copy1D(gate->y, cTAddOperand, 0, cTUnits, 0);
+	add1D(cTIn, cTAddOperand, cTOut);
+	copy1D(gate->y, hTOut, cTUnits, hTUnits, 0);
+	copy1D(hTOut, y);
 
 }
-void muTSBpg::bwd() {
+void muTS::bwd() {
 
-	muTSBwd(xUnits, cTUnits, hTUnits, comp_LenCTUnits, comp_LenHTUnits, xGrad, yGrad, cTInGrad, cTOutGrad, hTInGrad, hTOutGrad, gate);
+	// import compuation cTypes
+	vector<ptr<cType>>* comp_LenCTUnitsVec = &comp_LenCTUnits->vVector;
+	ptr<cType> cTCopyOperand = comp_LenCTUnitsVec->at(0);
+
+	vector<ptr<cType>>* comp_LenHTUnitsVec = &comp_LenHTUnits->vVector;
+	ptr<cType> hTAddOperand = comp_LenHTUnitsVec->at(0);
+
+	model* gateBpg = (model*)gate.get();
+
+	add1D(yGrad, hTOutGrad, hTAddOperand);
+	copy1D(cTOutGrad, gateBpg->yGrad, 0, cTUnits, 0);
+	copy1D(hTAddOperand, gateBpg->yGrad, 0, hTUnits, cTUnits);
+	gateBpg->bwd();
+	copy1D(gateBpg->xGrad, cTCopyOperand, xUnits, cTUnits, 0);
+	add1D(cTCopyOperand, cTOutGrad, cTInGrad);
+	copy1D(gateBpg->xGrad, xGrad, 0, xUnits, 0);
+	copy1D(gateBpg->xGrad, hTInGrad, xUnits + cTUnits, hTUnits, 0);
 
 }
-void muTSBpg::modelWise(function<void(model*)> func) {
+void muTS::modelWise(function<void(model*)> func) {
 
 	func(this);
-	muTSModelWise(func, gate);
+	gate->modelWise(func);
 
 }
-ptr<model> muTSBpg::clone() {
+ptr<model> muTS::clone() {
 
-	muTSBpg* result = new muTSBpg(xUnits, cTUnits, hTUnits, gate->clone());
+	muTS* result = new muTS(xUnits, cTUnits, hTUnits, gate->clone());
 	return result;
 
 }
@@ -1766,6 +987,11 @@ mu::mu(int _xUnits, int _cTUnits, int _hTUnits) {
 	this->hTIn = make1D(hTUnits);
 	this->hTOut = make1D(hTUnits);
 
+	this->cTInGrad = make1D(cTUnits);
+	this->cTOutGrad = make1D(cTUnits);
+	this->hTInGrad = make1D(hTUnits);
+	this->hTOutGrad = make1D(hTUnits);
+
 	ptr<model> nlr = neuronLR(0.3);
 
 	ptr<model> gateTemplate = tnn({ xUnits + cTUnits + hTUnits, cTUnits + hTUnits }, { nlr, nlr });
@@ -1782,6 +1008,11 @@ mu::mu(int _xUnits, int _cTUnits, int _hTUnits, ptr<model> _gate) {
 	this->cTOut = make1D(cTUnits);
 	this->hTIn = make1D(hTUnits);
 	this->hTOut = make1D(hTUnits);
+
+	this->cTInGrad = make1D(cTUnits);
+	this->cTOutGrad = make1D(cTUnits);
+	this->hTInGrad = make1D(hTUnits);
+	this->hTOutGrad = make1D(hTUnits);
 
 	muTSTemplate = new muTS(xUnits, cTUnits, hTUnits, _gate);
 
@@ -1829,135 +1060,12 @@ void mu::incFwd(int a) {
 	copy1D(hT, hTOut);
 
 }
-void mu::modelWise(function<void(model*)> func) {
-
-	func(this);
-	muModelWise(func, muTSTemplate);
-
-}
-ptr<model> mu::clone() {
-
-	muTS* castedTemplate = (muTS*)muTSTemplate.get();
-	mu* result = new mu(xUnits, cTUnits, hTUnits, castedTemplate->gate->clone());
-	return result;
-
-}
-void mu::prep(int a) {
-	for (int i = 0; i < a; i++) {
-		prepared.push_back(muTSTemplate->clone());
-	}
-}
-void mu::unroll(int a) {
-	for (int i = 0; i < a; i++) {
-		push_back(prepared.at(size()));
-		x->vVector.push_back(new cType{});
-		y->vVector.push_back(new cType{});
-	}
-}
-void mu::clear() {
-	vector<ptr<model>>::clear();
-	x->vVector.clear();
-	y->vVector.clear();
-	clear1D(cTIn);
-	clear1D(hTIn);
-	clear1D(cTOut);
-	clear1D(hTOut);
-	index = 0;
-}
-
-muBpg::muBpg() {
-
-}
-muBpg::muBpg(int _xUnits, int _cTUnits, int _hTUnits) {
-
-	this->xUnits = _xUnits;
-	this->cTUnits = _cTUnits;
-	this->hTUnits = _hTUnits;
-
-	this->cTIn = make1D(cTUnits);
-	this->cTOut = make1D(cTUnits);
-	this->hTIn = make1D(hTUnits);
-	this->hTOut = make1D(hTUnits);
-
-	this->cTInGrad = make1D(cTUnits);
-	this->cTOutGrad = make1D(cTUnits);
-	this->hTInGrad = make1D(hTUnits);
-	this->hTOutGrad = make1D(hTUnits);
-
-	ptr<model> nlr = neuronLRBpg(0.3);
-
-	ptr<model> gateTemplate = tnnBpg({ xUnits + cTUnits + hTUnits, cTUnits + hTUnits }, { nlr, nlr });
-	muTSTemplate = new muTSBpg(xUnits, cTUnits, hTUnits, gateTemplate);
-
-}
-muBpg::muBpg(int _xUnits, int _cTUnits, int _hTUnits, ptr<model> _gate) {
-
-	this->xUnits = _xUnits;
-	this->cTUnits = _cTUnits;
-	this->hTUnits = _hTUnits;
-
-	this->cTIn = make1D(cTUnits);
-	this->cTOut = make1D(cTUnits);
-	this->hTIn = make1D(hTUnits);
-	this->hTOut = make1D(hTUnits);
-
-	this->cTInGrad = make1D(cTUnits);
-	this->cTOutGrad = make1D(cTUnits);
-	this->hTInGrad = make1D(hTUnits);
-	this->hTOutGrad = make1D(hTUnits);
-
-	muTSTemplate = new muTSBpg(xUnits, cTUnits, hTUnits, _gate);
-
-}
-void muBpg::fwd() {
-
-	incFwd(size() - index);
-
-}
-void muBpg::incFwd(int a) {
-
-	vector<ptr<cType>>* xVec = &x->vVector;
-	vector<ptr<cType>>* yVec = &y->vVector;
-
-	ptr<cType> cT = make1D(cTUnits);
-	ptr<cType> hT = make1D(hTUnits);
-
-	// if the current carry index is 0, it means that none of the timesteps have been carried forward yet
-	if (index == 0) {
-		copy1D(cTIn, cT);
-		copy1D(hTIn, hT);
-	}
-	else {
-		copy1D(cTOut, cT);
-		copy1D(hTOut, hT);
-	}
-
-	for (int j = 0; j < a; j++) {
-
-		muTSBpg* m = (muTSBpg*)at(index).get();
-		m->x = xVec->at(index);
-		m->cTIn = cT;
-		m->hTIn = hT;
-		m->fwd();
-		yVec->at(index) = m->y;
-		cT = m->cTOut;
-		hT = m->hTOut;
-
-		index++;
-
-	}
-
-
-	copy1D(cT, cTOut);
-	copy1D(hT, hTOut);
-
-}
-void muBpg::bwd() {
+void mu::bwd() {
 
 	incBwd(index);
 
 }
-void muBpg::incBwd(int a) {
+void mu::incBwd(int a) {
 
 	vector<ptr<cType>>* yGradVec = &yGrad->vVector;
 	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
@@ -1979,7 +1087,7 @@ void muBpg::incBwd(int a) {
 
 		index--;
 
-		muTSBpg* m = (muTSBpg*)at(index).get();
+		muTS* m = (muTS*)at(index).get();
 		m->yGrad = yGradVec->at(index);
 		m->cTOutGrad = cTGrad;
 		m->hTOutGrad = hTGrad;
@@ -1994,25 +1102,25 @@ void muBpg::incBwd(int a) {
 	copy1D(hTGrad, hTInGrad);
 
 }
-void muBpg::modelWise(function<void(model*)> func) {
+void mu::modelWise(function<void(model*)> func) {
 
 	func(this);
-	muModelWise(func, muTSTemplate);
+	muTSTemplate->modelWise(func);
 
 }
-ptr<model> muBpg::clone() {
+ptr<model> mu::clone() {
 
-	muTSBpg* castedTemplate = (muTSBpg*)muTSTemplate.get();
-	muBpg* result = new muBpg(xUnits, cTUnits, hTUnits, castedTemplate->gate->clone());
+	muTS* castedTemplate = (muTS*)muTSTemplate.get();
+	mu* result = new mu(xUnits, cTUnits, hTUnits, castedTemplate->gate->clone());
 	return result;
 
 }
-void muBpg::prep(int a) {
+void mu::prep(int a) {
 	for (int i = 0; i < a; i++) {
 		prepared.push_back(muTSTemplate->clone());
 	}
 }
-void muBpg::unroll(int a) {
+void mu::unroll(int a) {
 	for (int i = 0; i < a; i++) {
 		push_back(prepared.at(size()));
 		x->vVector.push_back(new cType{});
@@ -2021,7 +1129,7 @@ void muBpg::unroll(int a) {
 		yGrad->vVector.push_back(new cType{});
 	}
 }
-void muBpg::clear() {
+void mu::clear() {
 	vector<ptr<model>>::clear();
 	x->vVector.clear();
 	y->vVector.clear();
@@ -2046,9 +1154,11 @@ attTS::attTS(int _xUnits, int _hTUnits) {
 	this->xUnits = _xUnits;
 	this->hTUnits = _hTUnits;
 
-	// Initialize y, and hT vectors
+	// Initialize x, y, and hT vectors
 	this->hTIn = make1D(hTUnits);
+	this->hTInGrad = make1D(hTUnits);
 	this->y = make1D(xUnits);
+	this->yGrad = make1D(xUnits);
 
 	// Initialize the prepared vector
 	this->prepared = vector<ptr<model>>();
@@ -2061,10 +1171,17 @@ attTS::attTS(int _xUnits, int _hTUnits) {
 	seq* seqTemp = tnn({ xUnits + hTUnits, xUnits }, { nlr, nsm });
 	seqTemp->x = make1D(xUnits + hTUnits);
 	seqTemp->y = make1D(xUnits);
+	seqTemp->xGrad = make1D(xUnits + hTUnits);
+	seqTemp->yGrad = make1D(xUnits);
 	this->seqTemplate = seqTemp;
 
+	// Initialize the template's x and y vectors
+	seqTemplate->x = make1D(xUnits + hTUnits);
+	seqTemplate->y = make1D(xUnits);
+
 	// Initialize the computation result cType
-	comp_LenXUnits = make2D(1, xUnits);
+	comp_LenXUnits = make2D(2, xUnits);
+	comp_LenHTUnits = make2D(1, hTUnits);
 
 }
 attTS::attTS(int _xUnits, int _hTUnits, ptr<model> _seqTemplate) {
@@ -2075,7 +1192,9 @@ attTS::attTS(int _xUnits, int _hTUnits, ptr<model> _seqTemplate) {
 
 	// Initialize x, y, and hT vectors
 	this->hTIn = make1D(hTUnits);
+	this->hTInGrad = make1D(hTUnits);
 	this->y = make1D(xUnits);
+	this->yGrad = make1D(xUnits);
 
 	// Initialize the prepared vector
 	this->prepared = vector<ptr<model>>();
@@ -2084,26 +1203,83 @@ attTS::attTS(int _xUnits, int _hTUnits, ptr<model> _seqTemplate) {
 	seq* seqTemp = (seq*)_seqTemplate.get();
 	seqTemp->x = make1D(xUnits + hTUnits);
 	seqTemp->y = make1D(xUnits);
+	seqTemp->xGrad = make1D(xUnits + hTUnits);
+	seqTemp->yGrad = make1D(xUnits);
 	this->seqTemplate = seqTemp;
 
 	// Initialize the computation result cType
-	comp_LenXUnits = make2D(1, xUnits);
+	comp_LenXUnits = make2D(2, xUnits);
+	comp_LenHTUnits = make2D(1, hTUnits);
 
 }
 void attTS::fwd() {
 
-	attTSFwd(x, y, hTIn, comp_LenXUnits, xUnits, hTUnits, this, &index);
+	incFwd(size());
 
 }
 void attTS::incFwd(int a) {
 
-	attTSIncFwd(x, y, hTIn, comp_LenXUnits, xUnits, hTUnits, this, &index, a);
+	vector<ptr<cType>>* comp_LenXUnitsVec = &comp_LenXUnits->vVector;
+	ptr<cType> x_yproduct = comp_LenXUnitsVec->at(0);
+
+	// pull in references to input matrices to save compute
+	vector<ptr<cType>>* xVec = &x->vVector;
+
+	clear1D(y);
+
+	for (int j = 0; j < a; j++) {
+
+		model* m = at(index).get();
+		// set input to the model
+		concat(xVec->at(index), hTIn, m->x);
+		m->fwd();
+		mult1D(m->y, xVec->at(index), x_yproduct);
+		add1D(y, x_yproduct, y);
+
+		index++;
+
+	}
 
 }
+void attTS::bwd() {
+
+	incBwd(index);
+
+}
+void attTS::incBwd(int a) {
+
+	vector<ptr<cType>>* comp_LenXUnitsVec = &comp_LenXUnits->vVector;
+	ptr<cType> xGrad_copyResult = comp_LenXUnitsVec->at(0);
+	ptr<cType> y_yGradproduct = comp_LenXUnitsVec->at(1);
+
+	vector<ptr<cType>>* comp_LenHTUnitsVec = &comp_LenHTUnits->vVector;
+	ptr<cType> hTInGrad_copyResult = comp_LenHTUnitsVec->at(0);
+
+	// pull in references to input matrices to save compute
+	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
+	vector<ptr<cType>>* xVec = &x->vVector;
+
+	clear1D(hTInGrad);
+
+	for (int j = 0; j < a; j++) {
+
+		index--;
+		model* m = at(index).get();
+
+		mult1D(yGrad, xVec->at(index), m->yGrad);
+		m->bwd();
+		copy1D(m->xGrad, xGrad_copyResult, 0, xUnits, 0);
+		copy1D(m->xGrad, hTInGrad_copyResult, xUnits, hTUnits, 0);
+		add1D(hTInGrad, hTInGrad_copyResult, hTInGrad);
+		mult1D(yGrad, m->y, y_yGradproduct);
+		add1D(y_yGradproduct, xGrad_copyResult, xGradVec->at(index));
+
+	}
+}
 void attTS::modelWise(function<void(model*)> func) {
-	
+
 	func(this);
-	attTSModelWise(func, seqTemplate);
+	seqTemplate->modelWise(func);
 
 }
 ptr<model> attTS::clone() {
@@ -2120,128 +1296,6 @@ void attTS::prep(int a) {
 
 }
 void attTS::unroll(int a) {
-	
-	for (int i = 0; i < a; i++) {
-		push_back(prepared.at(size()));
-		x->vVector.push_back(make1D(xUnits));
-	}
-
-}
-void attTS::clear() {
-
-	vector<ptr<model>>::clear();
-	x->vVector.clear();
-	index = 0;
-
-}
-
-attTSBpg::attTSBpg() {
-
-}
-attTSBpg::attTSBpg(int _xUnits, int _hTUnits) {
-
-	// Make the xUnits and hTUnits publicly accessable
-	this->xUnits = _xUnits;
-	this->hTUnits = _hTUnits;
-
-	// Initialize x, y, and hT vectors
-	this->hTIn = make1D(hTUnits);
-	this->hTInGrad = make1D(hTUnits);
-	this->y = make1D(xUnits);
-	this->yGrad = make1D(xUnits);
-
-	// Initialize the prepared vector
-	this->prepared = vector<ptr<model>>();
-
-	// Instantiate neurons that will be used in attention template TNN
-	ptr<model> nlr = neuronLRBpg(0.3);
-	ptr<model> nsm = neuronSmBpg();
-
-	// Initialize the attention timestep template model to be a tnn
-	seqBpg* seqTemp = tnnBpg({ xUnits + hTUnits, xUnits }, { nlr, nsm });
-	seqTemp->x = make1D(xUnits + hTUnits);
-	seqTemp->y = make1D(xUnits);
-	seqTemp->xGrad = make1D(xUnits + hTUnits);
-	seqTemp->yGrad = make1D(xUnits);
-	this->seqTemplate = seqTemp;
-
-	// Initialize the template's x and y vectors
-	seqTemplate->x = make1D(xUnits + hTUnits);
-	seqTemplate->y = make1D(xUnits);
-
-	// Initialize the computation result cType
-	comp_LenXUnits = make2D(2, xUnits);
-	comp_LenHTUnits = make2D(1, hTUnits);
-
-}
-attTSBpg::attTSBpg(int _xUnits, int _hTUnits, ptr<model> _seqTemplate) {
-
-	// Make the xUnits and hTUnits publicly accessable
-	this->xUnits = _xUnits;
-	this->hTUnits = _hTUnits;
-
-	// Initialize x, y, and hT vectors
-	this->hTIn = make1D(hTUnits);
-	this->hTInGrad = make1D(hTUnits);
-	this->y = make1D(xUnits);
-	this->yGrad = make1D(xUnits);
-
-	// Initialize the prepared vector
-	this->prepared = vector<ptr<model>>();
-
-	// Initialize the attention timestep template model to be a tnn
-	seqBpg* seqTemp = (seqBpg*)_seqTemplate.get();
-	seqTemp->x = make1D(xUnits + hTUnits);
-	seqTemp->y = make1D(xUnits);
-	seqTemp->xGrad = make1D(xUnits + hTUnits);
-	seqTemp->yGrad = make1D(xUnits);
-	this->seqTemplate = seqTemp;
-
-	// Initialize the computation result cType
-	comp_LenXUnits = make2D(2, xUnits);
-	comp_LenHTUnits = make2D(1, hTUnits);
-
-}
-void attTSBpg::fwd() {
-
-	attTSFwd(x, y, hTIn, comp_LenXUnits, xUnits, hTUnits, this, &index);
-
-}
-void attTSBpg::incFwd(int a) {
-
-	attTSIncFwd(x, y, hTIn, comp_LenXUnits, xUnits, hTUnits, this, &index, a);
-
-}
-void attTSBpg::bwd() {
-
-	attTSBwd(x, yGrad, xGrad, hTInGrad, comp_LenXUnits, comp_LenHTUnits, xUnits, hTUnits, this, &index);
-
-}
-void attTSBpg::incBwd(int a) {
-
-	attTSIncBwd(x, yGrad, xGrad, hTInGrad, comp_LenXUnits, comp_LenHTUnits, xUnits, hTUnits, this, &index, a);
-
-}
-void attTSBpg::modelWise(function<void(model*)> func) {
-
-	func(this);
-	attTSModelWise(func, seqTemplate);
-
-}
-ptr<model> attTSBpg::clone() {
-
-	attTSBpg* result = new attTSBpg(xUnits, hTUnits, seqTemplate);
-	return result;
-
-}
-void attTSBpg::prep(int a) {
-
-	for (int i = 0; i < a; i++) {
-		prepared.push_back(seqTemplate->clone());
-	}
-
-}
-void attTSBpg::unroll(int a) {
 
 	for (int i = 0; i < a; i++) {
 		push_back(prepared.at(size()));
@@ -2250,7 +1304,7 @@ void attTSBpg::unroll(int a) {
 	}
 
 }
-void attTSBpg::clear() {
+void attTS::clear() {
 
 	vector<ptr<model>>::clear();
 	x->vVector.clear();
@@ -2271,12 +1325,17 @@ att::att(int _xUnits, int _hTUnits) {
 	this->x = new cType{};
 	this->hTIn = new cType{};
 
+	this->xGrad = new cType{};
+	this->hTInGrad = new cType{};
+
 	// Initialize the prepared vector
 	this->prepared = vector<ptr<model>>();
 
 	// Initialize template model
-	this->attTSTemplate = new attTS(xUnits, hTUnits);
-	attTSTemplate->y = make1D(xUnits);
+	attTS* attTSTemplateBpg = new attTS(xUnits, hTUnits);
+	attTSTemplateBpg->y = make1D(xUnits);
+	attTSTemplateBpg->yGrad = make1D(xUnits);
+	this->attTSTemplate = attTSTemplateBpg;
 
 }
 att::att(int _xUnits, int _hTUnits, ptr<model> _attTSTemplate) {
@@ -2288,17 +1347,33 @@ att::att(int _xUnits, int _hTUnits, ptr<model> _attTSTemplate) {
 	this->x = new cType{};
 	this->hTIn = new cType{};
 
+	this->xGrad = new cType{};
+	this->hTInGrad = new cType{};
+
 	// Initialize the prepared vector
 	this->prepared = vector<ptr<model>>();
 
 	// Initialize template model
-	this->attTSTemplate = _attTSTemplate;
-	attTSTemplate->y = make1D(xUnits);
+	attTS* attTSTemplateBpg = (attTS*)_attTSTemplate.get();
+	attTSTemplateBpg->y = make1D(xUnits);
+	attTSTemplateBpg->yGrad = make1D(xUnits);
+	this->attTSTemplate = attTSTemplateBpg;
 
 }
 void att::fwd() {
 
-	incFwd(size() - index);
+	// pull in reference to vector to save compute
+	vector<ptr<cType>>* yVec = &y->vVector;
+	// In reality, this vector is a vector of vectors, so a matrix.
+	vector<ptr<cType>>* hTInMat = &hTIn->vVector;
+
+	attTS* a = (attTS*)at(index).get();
+	a->x = x;
+	a->hTIn = hTInMat->at(index);
+	a->fwd();
+	yVec->at(index) = a->y;
+
+	index++;
 
 }
 void att::incFwd(int _a) {
@@ -2317,6 +1392,32 @@ void att::incFwd(int _a) {
 		yVec->at(index) = a->y;
 
 		index++;
+
+	}
+
+}
+void att::bwd() {
+
+	incBwd(index);
+
+}
+void att::incBwd(int _a) {
+
+	// pull in reference to vector to save compute
+	vector<ptr<cType>>* yGradVec = &yGrad->vVector;
+	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
+	// In reality, this vector is a vector of vectors, so a matrix.
+	vector<ptr<cType>>* hTInGradMat = &hTInGrad->vVector;
+
+	for (int j = 0; j < _a; j++) {
+
+		index--;
+
+		attTS* a = (attTS*)at(index).get();
+		a->yGrad = yGradVec->at(index);
+		a->bwd();
+		add2D(xGrad, a->xGrad, xGrad);
+		hTInGradMat->at(index) = a->hTInGrad;
 
 	}
 
@@ -2356,9 +1457,11 @@ void att::unroll(int a) {
 
 		push_back(prepared.at(size()));
 		x->vVector.push_back(make1D(xUnits));
+		xGrad->vVector.push_back(make1D(xUnits));
 		y->vVector.push_back(new cType{});
+		yGrad->vVector.push_back(new cType{});
 		hTIn->vVector.push_back(new cType{});
-		// x's vVector is not pushed back to because it is completely populated by the user before any timestep is carried forward
+		hTInGrad->vVector.push_back(new cType{});
 
 	}
 
@@ -2367,201 +1470,23 @@ void att::unroll(int a, int b) {
 
 	for (int i = 0; i < a; i++) {
 
+		int s = size();
 		ptr<model> m = prepared.at(size());
 		attTS* att = (attTS*)m.get();
 		att->unroll(b);
 		push_back(m);
 		x->vVector.push_back(make1D(xUnits));
+		xGrad->vVector.push_back(make1D(xUnits));
 		y->vVector.push_back(new cType{});
+		yGrad->vVector.push_back(new cType{});
 		hTIn->vVector.push_back(new cType{});
+		hTInGrad->vVector.push_back(new cType{});
 		// x's vVector is not pushed back to because it is completely populated by the user before any timestep is carried forward
 
 	}
 
 }
 void att::clear() {
-
-	vector<ptr<model>>::clear();
-	x->vVector.clear();
-	y->vVector.clear();
-	hTIn->vVector.clear();
-
-}
-
-attBpg::attBpg() {
-
-}
-attBpg::attBpg(int _xUnits, int _hTUnits) {
-
-	// Make the xUnits and hTUnits publicly accessable
-	this->xUnits = _xUnits;
-	this->hTUnits = _hTUnits;
-
-	this->x = new cType{};
-	this->hTIn = new cType{};
-
-	this->xGrad = new cType{};
-	this->hTInGrad = new cType{};
-
-	// Initialize the prepared vector
-	this->prepared = vector<ptr<model>>();
-
-	// Initialize template model
-	attTSBpg* attTSTemplateBpg = new attTSBpg(xUnits, hTUnits);
-	attTSTemplateBpg->y = make1D(xUnits);
-	attTSTemplateBpg->yGrad = make1D(xUnits);
-	this->attTSTemplate = attTSTemplateBpg;
-
-}
-attBpg::attBpg(int _xUnits, int _hTUnits, ptr<model> _attTSTemplate) {
-
-	// Make the xUnits and hTUnits publicly accessable
-	this->xUnits = _xUnits;
-	this->hTUnits = _hTUnits;
-
-	this->x = new cType{};
-	this->hTIn = new cType{};
-
-	this->xGrad = new cType{};
-	this->hTInGrad = new cType{};
-
-	// Initialize the prepared vector
-	this->prepared = vector<ptr<model>>();
-
-	// Initialize template model
-	attTSBpg* attTSTemplateBpg = (attTSBpg*)_attTSTemplate.get();
-	attTSTemplateBpg->y = make1D(xUnits);
-	attTSTemplateBpg->yGrad = make1D(xUnits);
-	this->attTSTemplate = attTSTemplateBpg;
-
-}
-void attBpg::fwd() {
-
-	// pull in reference to vector to save compute
-	vector<ptr<cType>>* yVec = &y->vVector;
-	// In reality, this vector is a vector of vectors, so a matrix.
-	vector<ptr<cType>>* hTInMat = &hTIn->vVector;
-
-	attTSBpg* a = (attTSBpg*)at(index).get();
-	a->x = x;
-	a->hTIn = hTInMat->at(index);
-	a->fwd();
-	yVec->at(index) = a->y;
-
-	index++;
-
-}
-void attBpg::incFwd(int _a) {
-
-	// pull in reference to vector to save compute
-	vector<ptr<cType>>* yVec = &y->vVector;
-	// In reality, this vector is a vector of vectors, so a matrix.
-	vector<ptr<cType>>* hTInMat = &hTIn->vVector;
-
-	for (int j = 0; j < _a; j++) {
-
-		attTSBpg* a = (attTSBpg*)at(index).get();
-		a->x = x;
-		a->hTIn = hTInMat->at(index);
-		a->fwd();
-		yVec->at(index) = a->y;
-
-		index++;
-
-	}
-
-}
-void attBpg::bwd() {
-
-	incBwd(index);
-
-}
-void attBpg::incBwd(int _a) {
-
-	// pull in reference to vector to save compute
-	vector<ptr<cType>>* yGradVec = &yGrad->vVector;
-	vector<ptr<cType>>* xGradVec = &xGrad->vVector;
-	// In reality, this vector is a vector of vectors, so a matrix.
-	vector<ptr<cType>>* hTInGradMat = &hTInGrad->vVector;
-
-	for (int j = 0; j < _a; j++) {
-
-		index--;
-
-		attTSBpg* a = (attTSBpg*)at(index).get();
-		a->yGrad = yGradVec->at(index);
-		a->bwd();
-		add2D(xGrad, a->xGrad, xGrad);
-		hTInGradMat->at(index) = a->hTInGrad;
-
-	}
-
-}
-void attBpg::modelWise(function<void(model*)> func) {
-
-	func(this);
-	attTSTemplate->modelWise(func);
-
-}
-ptr<model> attBpg::clone() {
-
-	attBpg* result = new attBpg(xUnits, hTUnits, attTSTemplate->clone());
-	return result;
-
-}
-void attBpg::prep(int a) {
-
-	for (int i = 0; i < a; i++) {
-		prepared.push_back(attTSTemplate->clone());
-	}
-
-}
-void attBpg::prep(int a, int b) {
-
-	for (int i = 0; i < a; i++) {
-		ptr<model> m = attTSTemplate->clone();
-		attTSBpg* att = (attTSBpg*)m.get();
-		att->prep(b);
-		prepared.push_back(m);
-	}
-
-}
-void attBpg::unroll(int a) {
-
-	for (int i = 0; i < a; i++) {
-
-		push_back(prepared.at(size()));
-		x->vVector.push_back(make1D(xUnits));
-		xGrad->vVector.push_back(make1D(xUnits));
-		y->vVector.push_back(new cType{});
-		yGrad->vVector.push_back(new cType{});
-		hTIn->vVector.push_back(new cType{});
-		hTInGrad->vVector.push_back(new cType{});
-
-	}
-
-}
-void attBpg::unroll(int a, int b) {
-
-	for (int i = 0; i < a; i++) {
-
-		int s = size();
-		ptr<model> m = prepared.at(size());
-		attTSBpg* att = (attTSBpg*)m.get();
-		att->unroll(b);
-		push_back(m);
-		x->vVector.push_back(make1D(xUnits));
-		xGrad->vVector.push_back(make1D(xUnits));
-		y->vVector.push_back(new cType{});
-		yGrad->vVector.push_back(new cType{});
-		hTIn->vVector.push_back(new cType{});
-		hTInGrad->vVector.push_back(new cType{});
-		// x's vVector is not pushed back to because it is completely populated by the user before any timestep is carried forward
-
-	}
-
-}
-void attBpg::clear() {
 
 	vector<ptr<model>>::clear();
 	x->vVector.clear();

--- a/dev/windows/AuroraCPP/AuroraCPP/modeling.h
+++ b/dev/windows/AuroraCPP/AuroraCPP/modeling.h
@@ -7,25 +7,13 @@
 
 #define MODELFIELDS \
 virtual void fwd();\
+virtual void bwd();\
 virtual ptr<model> clone();
-
-#define MODELBPGFIELDS MODELFIELDS \
-virtual void bwd();
 
 #define SEQFIELDS MODELFIELDS \
 virtual void modelWise(function<void(model*)> func);
 
-#define SEQBPGFIELDS MODELBPGFIELDS \
-virtual void modelWise(function<void(model*)> func);
-
 #define RECFIELDS SEQFIELDS \
-virtual void incFwd(int a);\
-virtual void prep(int a);\
-virtual void unroll(int a);\
-virtual void clear(); \
-int index;
-
-#define RECBPGFIELDS SEQBPGFIELDS \
 virtual void incFwd(int a);\
 virtual void incBwd(int a);\
 virtual void prep(int a);\
@@ -38,79 +26,50 @@ RECFIELDS \
 virtual void prep(int a, int b);\
 virtual void unroll(int a, int b);
 
-#define ATTBPGFIELDS \
-RECBPGFIELDS \
-virtual void prep(int a, int b);\
-virtual void unroll(int a, int b);
-
 
 #pragma endregion
 
 class model;
-class modelBpg;
 class bias;
-class biasBpg;
 class act;
-class actBpg;
 class weight;
-class weightBpg;
 class wSet;
-class wSetBpg;
 class wJunc;
-class wJuncBpg;
 class seq;
-class seqBpg;
 class layer;
-class layerBpg;
 class sync;
-class syncBpg;
 class lstmTS;
-class lstmTSBpg;
 class lstm;
-class lstmBpg;
 class muTS;
-class muTSBpg;
 class mu;
-class muBpg;
 class attTS;
-class attTSBpg;
+class att;
 
 seq* tnn(vector<int> npl, vector<ptr<model>> layerNeuronTemplates);
-seqBpg* tnnBpg(vector<int> npl, vector<ptr<model>> layerNeuronTemplates);
-
 seq* tnn(vector<int> npl, ptr<model> neuronTemplate);
-seqBpg* tnnBpg(vector<int> npl, ptr<model> neuronTemplate);
 
 //seq* stackedLstm(int count, int units);
-//seqBpg* stackedLstmBpg(int count, int units);
+//seq* stackedlstm(int count, int units);
 
 seq* neuronSm();
 seq* neuronTh();
 seq* neuronLR(double m);
-seqBpg* neuronSmBpg();
-seqBpg* neuronThBpg();
-seqBpg* neuronLRBpg(double m);
 
 void initParam(model* m, vector<ptr<param>*>& paramVecOutput);
 
 //void attToLSTMFwd(att* a, lstm* l);
-//void attToLSTMFwd(attBpg* a, lstmBpg* l);
-//void attToLSTMBwd(attBpg* a, lstmBpg* l);
+//void attToLSTMFwd(att* a, lstm* l);
+//void attToLSTMBwd(att* a, lstm* l);
 
 class model {
 public:
 	model();
 	virtual void fwd();
+	virtual void bwd();
 	virtual void modelWise(function<void(model*)> func);
 	virtual ptr<model> clone();
 	ptr<cType> x;
 	ptr<cType> y;
-};
-class modelBpg : public model {
-public:
-	modelBpg();
-	virtual void bwd();
-	virtual ptr<model> clone();
 	ptr<cType> xGrad;
 	ptr<cType> yGrad;
 };
@@ -118,12 +77,6 @@ class bias : public model {
 public:
 	MODELFIELDS
 	bias();
-	ptr<param> prm;
-};
-class biasBpg : public modelBpg {
-public:
-	MODELBPGFIELDS
-	biasBpg();
 	ptr<param> prm;
 };
 class act : public model {
@@ -134,24 +87,10 @@ public:
 	act(ptr<actFunc> _af);
 	ptr<actFunc> af;
 };
-class actBpg : public modelBpg {
-public:
-	MODELBPGFIELDS
-	actBpg();
-	actBpg(actFunc* _af);
-	actBpg(ptr<actFunc> _af);
-	ptr<actFunc> af;
-};
 class weight : public model {
 public:
 	MODELFIELDS
 	weight();
-	ptr<param> prm;
-};
-class weightBpg : public modelBpg {
-public:
-	MODELBPGFIELDS
-	weightBpg();
 	ptr<param> prm;
 };
 class wSet : public model, public vector<ptr<model>> {
@@ -159,13 +98,6 @@ public:
 	SEQFIELDS
 	wSet();
 	wSet(int _a);
-	int a;
-};
-class wSetBpg : public modelBpg, public vector<ptr<model>> {
-public:
-	SEQBPGFIELDS
-	wSetBpg();
-	wSetBpg(int _a);
 	int a;
 };
 class wJunc : public model, public vector<ptr<model>> {
@@ -176,23 +108,10 @@ public:
 	int a;
 	int b;
 };
-class wJuncBpg : public modelBpg, public vector<ptr<model>> {
-public:
-	SEQBPGFIELDS
-	wJuncBpg();
-	wJuncBpg(int _a, int _b);
-	int a;
-	int b;
-};
 class seq : public model, public vector<ptr<model>> {
 public:
 	SEQFIELDS
 	seq();
-};
-class seqBpg : public modelBpg, public vector<ptr<model>> {
-public:
-	SEQBPGFIELDS
-	seqBpg();
 };
 class layer : public model, public vector<ptr<model>> {
 public:
@@ -200,13 +119,6 @@ public:
 	layer();
 	layer(int a, model* modelTemplate);
 	layer(int a, ptr<model> modelTemplate);
-};
-class layerBpg : public modelBpg, public vector<ptr<model>> {
-public:
-	SEQBPGFIELDS
-	layerBpg();
-	layerBpg(int a, model* modelTemplate);
-	layerBpg(int a, ptr<model> modelTemplate);
 };
 class sync : public model, public vector<ptr<model>> {
 public:
@@ -220,44 +132,11 @@ public:
 	// template model that will be cloned when prep() is called
 	ptr<model> modelTemplate;
 };
-class syncBpg : public modelBpg, public vector<ptr<model>> {
-public:
-	RECBPGFIELDS
-	syncBpg();
-	syncBpg(model* _modelTemplate);
-	syncBpg(ptr<model> _modelTemplate);
-
-	// models that have been instantiated in RAM, and therefore are ready to be unrolled when ready to use
-	vector<ptr<model>> prepared;
-	// template model that will be cloned when prep() is called
-	ptr<model> modelTemplate;
-};
 class lstmTS : public model {
 public:
 	SEQFIELDS
 	lstmTS();
 	lstmTS(int _units, ptr<model> _aGate, ptr<model> _bGate, ptr<model> _cGate, ptr<model> _dGate);
-
-	int units;
-
-	ptr<model> aGate;
-	ptr<model> bGate;
-	ptr<model> cGate;
-	ptr<model> dGate;
-
-	ptr<cType> cTIn;
-	ptr<cType> cTOut;
-	ptr<cType> hTIn;
-	ptr<cType> hTOut;
-private:
-	ptr<cType> comp_LenUnits;
-	ptr<cType> comp_Len2Units;
-};
-class lstmTSBpg : public modelBpg {
-public:
-	SEQBPGFIELDS
-	lstmTSBpg();
-	lstmTSBpg(int _units, ptr<model> _aGate, ptr<model> _bGate, ptr<model> _cGate, ptr<model> _dGate);
 
 	int units;
 
@@ -284,29 +163,9 @@ public:
 	RECFIELDS
 	lstm();
 	lstm(int _units);
-	//lstm(int _units, vector<int> _gateHiddenLayers);
+	//lstm(int _units, vector<int> gateHiddenLayers);
 	//lstm(int _units, vector<int> _aGateHiddenLayers, vector<int> _bGateHiddenLayers, vector<int> _cGateHiddenLayers, vector<int> _dGateHiddenLayers);
 	lstm(int _units, ptr<model> _aGate, ptr<model> _bGate, ptr<model> _cGate, ptr<model> _dGate);
-
-	int units;
-	// models that have been instantiated in RAM, and therefore are ready to be unrolled when ready to use
-	vector<ptr<model>> prepared;
-	// template model that will be cloned when prep() is called
-	ptr<model> lstmTSTemplate;
-
-	ptr<cType> cTIn;
-	ptr<cType> cTOut;
-	ptr<cType> hTIn;
-	ptr<cType> hTOut;
-};
-class lstmBpg : public modelBpg, public vector<ptr<model>> {
-public:
-	RECBPGFIELDS
-	lstmBpg();
-	lstmBpg(int _units);
-	//lstmBpg(int _units, vector<int> gateHiddenLayers);
-	//lstmBpg(int _units, vector<int> _aGateHiddenLayers, vector<int> _bGateHiddenLayers, vector<int> _cGateHiddenLayers, vector<int> _dGateHiddenLayers);
-	lstmBpg(int _units, ptr<model> _aGate, ptr<model> _bGate, ptr<model> _cGate, ptr<model> _dGate);
 
 	int units;
 	// models that have been instantiated in RAM, and therefore are ready to be unrolled when ready to use
@@ -340,25 +199,6 @@ public:
 	ptr<cType> cTOut;
 	ptr<cType> hTIn;
 	ptr<cType> hTOut;
-private:
-	ptr<cType> comp_LenCTUnits;
-};
-class muTSBpg : public modelBpg {
-public:
-	SEQBPGFIELDS
-	muTSBpg();
-	muTSBpg(int _xUnits, int _cTUnits, int _hTUnits, ptr<model> _gate);
-
-	int xUnits;
-	int cTUnits;
-	int hTUnits;
-
-	ptr<model> gate;
-
-	ptr<cType> cTIn;
-	ptr<cType> cTOut;
-	ptr<cType> hTIn;
-	ptr<cType> hTOut;
 
 	ptr<cType> cTInGrad;
 	ptr<cType> cTOutGrad;
@@ -373,30 +213,8 @@ public:
 	RECFIELDS
 	mu();
 	mu(int _xUnits, int _cTUnits, int _hTUnits);
-	//mu(int _xUnits, int _cTUnits, int _hTUnits, vector<int> _gateHiddenLayers);
-	mu(int _xUnits, int _cTUnits, int _hTUnits, ptr<model> _gate);
-
-	int xUnits;
-	int cTUnits;
-	int hTUnits;
-
-	// models that have been instantiated in RAM, and therefore are ready to be unrolled when ready to use
-	vector<ptr<model>> prepared;
-	// template model that will be cloned when prep() is called
-	ptr<model> muTSTemplate;
-
-	ptr<cType> cTIn;
-	ptr<cType> cTOut;
-	ptr<cType> hTIn;
-	ptr<cType> hTOut;
-};
-class muBpg : public modelBpg, public vector<ptr<model>> {
-public:
-	RECBPGFIELDS
-	muBpg();
-	muBpg(int _xUnits, int _cTUnits, int _hTUnits);
-	//muBpg(int _xUnits, int _cTUnits, int _hTUnits, vector<int> gateHiddenLayers);
-	muBpg(int _xUnits, int _cTUnits, int _hTUnits, ptr<model> gate);
+	//mu(int _xUnits, int _cTUnits, int _hTUnits, vector<int> gateHiddenLayers);
+	mu(int _xUnits, int _cTUnits, int _hTUnits, ptr<model> gate);
 
 	int xUnits;
 	int cTUnits;
@@ -428,26 +246,7 @@ public:
 	int hTUnits;
 	// models that have been instantiated in RAM, and therefore are ready to be unrolled when ready to use
 	vector<ptr<model>> prepared;
-	// template model that will be cloned when prep() is called
-	ptr<model> seqTemplate;
-	// the input hidden state is a vector, because it intakes one vector representing the decoder lstm's previous hTOut
-	ptr<cType> hTIn;
-
-private:
-	ptr<cType> comp_LenXUnits;
-};
-class attTSBpg : public modelBpg, public vector<ptr<model>> {
-public:
-	RECBPGFIELDS
-	attTSBpg();
-	attTSBpg(int _xUnits, int _hTUnits);
-	attTSBpg(int _xUnits, int _hTUnits, ptr<model> _seqTemplate);
-
-	int xUnits;
-	int hTUnits;
-	// models that have been instantiated in RAM, and therefore are ready to be unrolled when ready to use
-	vector<ptr<model>> prepared;
-	// the template model is a sequential (using the attTSBpg(int, int) constructor, this will be a traditional neural network)
+	// the template model is a sequential (using the attTS(int, int) constructor, this will be a traditional neural network)
 	ptr<model> seqTemplate;
 	// the input hidden state is a vector, because it intakes one vector representing the decoder lstm's previous hTOut
 	ptr<cType> hTIn;
@@ -463,23 +262,6 @@ public:
 	att();
 	att(int _xUnits, int _hTUnits);
 	att(int _xUnits, int _hTUnits, ptr<model> _attTSTemplate);
-
-	int xUnits;
-	int hTUnits;
-
-	// models that have been instantiated in RAM, and therefore are ready to be unrolled when ready to use
-	vector<ptr<model>> prepared;
-	// the template model is an attTS (attention timestep)
-	ptr<model> attTSTemplate;
-	// the input hidden state is a matrix, because it intakes one vector representing the decoder lstm's hidden state at every timestep
-	ptr<cType> hTIn;
-};
-class attBpg : public modelBpg, public vector<ptr<model>> {
-public:
-	ATTBPGFIELDS
-	attBpg();
-	attBpg(int _xUnits, int _hTUnits);
-	attBpg(int _xUnits, int _hTUnits, ptr<model> _attTSTemplate);
 
 	int xUnits;
 	int hTUnits;


### PR DESCRIPTION
Vindicated the code base's quality, and refactored allowing for much less identical code between the modelBpgs and models.

Removed the external functions for use between the models and modelBpgs.

The new "current" model classes are listed below:
class model;
class bias;
class act;
class weight;
class wSet;
class wJunc;
class seq;
class layer;
class sync;
class lstmTS;
class lstm;
class muTS;
class mu;
class attTS;
class att;

All default models have been removed and all modelBpgs have been renamed to fill the void caused by the removals thereof.
E.g. :
modelBpg -(renamed to be)-> model
biasBpg     -(renamed to be)-> bias
actBpg       -(renamed to be)-> act